### PR TITLE
fix cache lookup URL

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -113,6 +113,7 @@ func CreateCache() (*Cache, error) {
 func (c *Cache) has(requestedURL string) (*sync.Mutex, bool) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+	olo.Debug("checking cache for requestedURL %s", requestedURL)
 
 	// If the resource is busy, wait for it to be free. This is the case if
 	// the resource is currently being cached as a result of another request.
@@ -123,6 +124,8 @@ func (c *Cache) has(requestedURL string) (*sync.Mutex, bool) {
 		lock.Unlock()
 		c.mutex.Lock()
 	}
+
+	// fmt.Printf("%+v\n", c.cacheMemoryItems)
 
 	// If a resource is in the shared cache, it can't be reserved. One can simply
 	// access it directly from the cache
@@ -170,7 +173,7 @@ func (c *Cache) get(requestedURL string, defaultCacheTTL time.Duration) (CacheRe
 
 	// Key is known, but not found in-memory, read from file
 	if cacheMemoryItem.content == nil {
-		olo.Debug("Cache item '%s' known but is not stored in memory. Reading from file: %s", cacheURL, cacheFile)
+		olo.Debug("Cache item '%s' is known but is not stored in memory. Reading from file: %s", cacheURL, cacheFile)
 
 		file, err := os.Open(cacheFile)
 		if err != nil {
@@ -217,7 +220,7 @@ func (c *Cache) put(requestedURL string, content *io.Reader, contentLength int64
 		cacheFolder = config.CacheFolderHTTPS
 	}
 	urlParts := strings.SplitN(requestedURL, "/", 4)
-	olo.Debug("adding to cache folder %s the url part 2 %s\n", cacheFolder, urlParts[2])
+	olo.Debug("adding to cache folder %s the url part 2 %s", cacheFolder, urlParts[2])
 	fileCacheDir := filepath.Join(cacheFolder, urlParts[2])
 	_, err := h.CheckDirAndCreate(fileCacheDir, "Cache.put")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -164,9 +164,9 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 		handleError(nil, err, w)
 		return
 	}
-	olo.Info("Incoming request '%s' from '%s' on '%s'", r.URL.Path, requesterIP, r.URL.Host)
+	olo.Info("Incoming request '%s' from '%s' on '%s'", r.URL.Path, requesterIP, r.Host)
 	if r.Method != "GET" {
-		olo.Warn("Incoming nonGET HTTP request '%s' from '%s' on '%s'", r.URL.Path, requesterIP, r.URL.Host)
+		olo.Warn("Incoming nonGET HTTP request '%s' from '%s' on '%s'", r.URL.Path, requesterIP, r.Host)
 		errorMessage := fmt.Sprintf("HTTP method '%s' other than GET not allowed for '%s' from '%s' on '%s'", r.Method, r.URL, requesterIP, r.Host)
 		promCounters["TOTAL_HTTP_NONGET_REQUESTS"].Inc()
 		handleError(nil, errors.New(errorMessage), w)
@@ -222,8 +222,8 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cache miss -> Load data from requested URL and add to cache
-	if busy, ok := cache.has(cacheURL); !ok {
-		olo.Info("CACHE_MISS for requested '%s'", cacheURL)
+	if busy, ok := cache.has(fullUrl); !ok {
+		olo.Info("CACHE_MISS for requested '%s'", fullUrl)
 		promCounters["CACHE_MISS"].Inc()
 		defer busy.Unlock()
 		response, err := GetRemote(fullUrl)


### PR DESCRIPTION
* use full remote URL (with http and https) for the `Cache.has()` lookup, fixes cache misses
* disabled non GET HTTP requests 
* set Content-Disposition response header