### PR TITLE
Some improvements to tiny-http-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All the configuration is done in a YAML config file:
 | `ssl_private_key` | `string` | File with SSL key to use on SSL port. |
 | `ssl_certificate_file` | `string` | File with SSL certificate to use on SSL port. |
 | `cache_folder` | `string` | The folder where the cache files are stored. This folder must exist and must be writable. |
+| `local_root` | `string` | Local folder to serve as /local/... |
 | `debug` | `bool` | When set to true, more detailed log output is printed. |
 | `max_cache_item_size_in_mb` | `int` | Maximum size in MB for the in-memory cache. Larger files are only read from disk, smaller files are delivered directly from the memory. |
 | `caching_rules` | `map[string]CachingRules` | Can contain regex patterns for which cache rules can be specified, see details. |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ All the configuration is done in a YAML config file:
 
 | Property | Type | Description |
 |:---|:---|:---|
-| `port` | `string` | The port this server is listening to. |
+| `listen_address` | `string` | Address (default 0.0.0.0) to listen for requests. |
+| `listen_port` | `string` | The port this server is listening to for http (0 disables). |
+| `listen_ssl_port` | `string` | The port this server is listening to for https (0 disables). |
+| `ssl_private_key` | `string` | File with SSL key to use on SSL port. |
+| `ssl_certificate_file` | `string` | File with SSL certificate to use on SSL port. |
 | `cache_folder` | `string` | The folder where the cache files are stored. This folder must exist and must be writable. |
 | `debug` | `bool` | When set to true, more detailed log output is printed. |
 | `max_cache_item_size_in_mb` | `int` | Maximum size in MB for the in-memory cache. Larger files are only read from disk, smaller files are delivered directly from the memory. |

--- a/cache.go
+++ b/cache.go
@@ -277,7 +277,6 @@ func checkCacheTTL(filePath string, requestedURL string, defaultCacheTTL time.Du
 			return err
 		}
 		olo.Error("found cache item while starting service, but it was removed afterwards, trying to get it again: '%s'", requestedURL)
-		olo.Fatal("found cache item while starting service, but it was removed afterwards, trying to get it again: '%s'", requestedURL)
 		err = checkCacheTTL(filePath, requestedURL, defaultCacheTTL)
 		if err != nil {
 			return err

--- a/config.go
+++ b/config.go
@@ -52,7 +52,7 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	var config Config
-	err = yaml.Unmarshal(file, &config)
+	err = yaml.UnmarshalStrict(file, &config)
 
 	if err != nil {
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	CertificateFile            string                  `yaml:"ssl_certificate_file"`
 	Proxy                      string                  `yaml:"proxy"`
 	ProxyURL                   *url.URL                `yaml:"proxyURL"`
+	LocalRoot                  string                  `yaml:"local_root"`
 	CacheFolder                string                  `yaml:"cache_folder"`
 	CacheFolderHTTPS           string                  `yaml:"cache_folder_https"`
 	DefaultCacheTTLString      string                  `yaml:"default_cache_ttl"`

--- a/main.go
+++ b/main.go
@@ -68,9 +68,8 @@ func main() {
 
 	// prometheus metrics server
 	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe("127.0.0.1:2112", nil)
 	olo.Info("Listening on http://127.0.0.1:2112/metrics")
-
+	olo.Fatal(http.ListenAndServe("127.0.0.1:8082", nil).Error())
 }
 
 func loadConfig(configFile string) {


### PR DESCRIPTION
Hi Paul.

Some time ago I was looking for a simple solution to access RPM packages while doing server installations that allows me to "archive" all used packages without the need to mirror whole repositories (where I never use most packages).
Looking for a simple "single binary" solution and also starting to learn Go I came across tiny-http-proxy and especially your modification of it, keeping the cache items with their original names and not as hashes. Thus even allowing to build new local repositories with all those cached files.
While "playing" with it, I have implemented some improvements that might also be interesting to you.

I also have a modification (not part of this pull request) to store the cache items in its original directory tree structure and not flat per server.