### PR TITLE
fix cache prefill for disk items

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -101,6 +101,9 @@ func CreateCache() (*Cache, error) {
 
 				olo.Debug("prefillCache: Added %s for %s back into in-memory cache with size of %d", path, cachedItem, size)
 			} else {
+				mutex.Lock()
+				memory[cachedItem] = CacheMemoryItem{content: nil, loadedAt: time.Now()}
+				mutex.Unlock()
 				olo.Debug("prefillCache: Added %s for %s back into known cache items, but will only read it from files as size is %d", path, cachedItem, fi.Size())
 			}
 		}
@@ -153,7 +156,7 @@ func (c *Cache) has(requestedURL string) (*sync.Mutex, bool) {
 		c.mutex.Lock()
 	}
 
-	// fmt.Printf("%+v\n", c.cacheMemoryItems)
+	// fmt.Printf("Cache.has() %+v\n", c.cacheMemoryItems)
 
 	// If a resource is in the shared cache, it can't be reserved. One can simply
 	// access it directly from the cache

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Timeout                    int      `yaml:"timeout_in_s"`
 	ProxyNetworkStrings        []string `yaml:"reverse_proxy_networks"`
 	ProxyNetworks              []net.IPNet
+	NoSSL                      bool                    `yaml:"no_ssl"`
 	PrivateKey                 string                  `yaml:"ssl_private_key"`
 	CertificateFile            string                  `yaml:"ssl_certificate_file"`
 	Proxy                      string                  `yaml:"proxy"`

--- a/config.go
+++ b/config.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"errors"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -47,7 +47,7 @@ type CachingRules struct {
 }
 
 func LoadConfig(path string) (*Config, error) {
-	file, err := ioutil.ReadFile(path)
+	file, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/example.yaml
+++ b/example.yaml
@@ -8,6 +8,7 @@ listen_ssl_port: 8443
 timeout_in_s: 500
 return_cache_if_remote_fails: true
 #proxy: http://proxy.domain.tld:3128
+no_ssl: true
 ssl_private_key: ./ssl/service.key
 ssl_certificate_file: ./ssl/service.pem
 cache_folder: ./cache/

--- a/main.go
+++ b/main.go
@@ -65,7 +65,9 @@ func main() {
 	olo.Debug("Cache initialized")
 
 	go serve()
-	go serveTLS()
+	if config.NoSSL != false {
+		go serveTLS()
+	}
 
 	// prometheus metrics server
 	http.Handle("/metrics", promhttp.Handler())

--- a/main.go
+++ b/main.go
@@ -65,7 +65,9 @@ func main() {
 	olo.Debug("Cache initialized")
 
 	go serve()
-	if config.NoSSL != false {
+	if config.NoSSL {
+		olo.Info("Not starting HTTPS server as no_ssl is set to true")
+	} else {
 		go serveTLS()
 	}
 


### PR DESCRIPTION
- fix cache prefill for disk only items that are larger than `max_cache_item_size_in_mb`
- add `no_ssl` config setting and set it to true to disable SSL for example.conf