### PR TITLE
Improve error responses for unreachable remote URLs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Run Golang Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test -v ./...

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// cachePath returns the on-disk path pkgproxy would use for rawURL.
+func cachePath(rawURL string) string {
+	parts := strings.SplitN(rawURL, "/", 4)
+	return filepath.Join(config.CacheFolder, parts[2], url.QueryEscape(parts[3]))
+}
+
+// TestCachingRuleServesFromCacheWhileFresh verifies that a URL matching a
+// caching rule is served from cache on the second request without hitting the
+// remote, as long as the rule's TTL has not expired.
+func TestCachingRuleServesFromCacheWhileFresh(t *testing.T) {
+	var backendCalls atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls.Add(1)
+		fmt.Fprint(w, "package-content")
+	}))
+	defer backend.Close()
+
+	config.CacheRules = map[string]CachingRules{
+		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "1h", TTL: time.Hour},
+	}
+	t.Cleanup(func() { config.CacheRules = nil })
+
+	path := "/" + strings.TrimPrefix(backend.URL, "http://") + "/package.rpm"
+
+	// First request: cache miss, must fetch from remote.
+	w1 := httptest.NewRecorder()
+	handleGet(w1, httptest.NewRequest("GET", path, nil))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first request: want 200, got %d", w1.Code)
+	}
+	if n := backendCalls.Load(); n != 1 {
+		t.Fatalf("first request: want 1 backend call, got %d", n)
+	}
+
+	// Second request: rule TTL is 1h, cache is fresh, remote must not be called again.
+	w2 := httptest.NewRecorder()
+	handleGet(w2, httptest.NewRequest("GET", path, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second request: want 200, got %d", w2.Code)
+	}
+	if n := backendCalls.Load(); n != 1 {
+		t.Errorf("second request: cache should be used, want 1 backend call total, got %d", n)
+	}
+}
+
+// TestCachingRuleRefreshesAfterExpiry verifies that once a caching rule's TTL
+// has elapsed the item is re-fetched from the remote.
+func TestCachingRuleRefreshesAfterExpiry(t *testing.T) {
+	var backendCalls atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls.Add(1)
+		fmt.Fprint(w, "package-content")
+	}))
+	defer backend.Close()
+
+	config.CacheRules = map[string]CachingRules{
+		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "30m", TTL: 30 * time.Minute},
+	}
+	t.Cleanup(func() { config.CacheRules = nil })
+
+	fullURL := "http://" + strings.TrimPrefix(backend.URL, "http://") + "/package.rpm"
+	path := "/" + strings.TrimPrefix(fullURL, "http://")
+
+	// First request: cache miss.
+	w1 := httptest.NewRecorder()
+	handleGet(w1, httptest.NewRequest("GET", path, nil))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first request: want 200, got %d", w1.Code)
+	}
+	if n := backendCalls.Load(); n != 1 {
+		t.Fatalf("first request: want 1 backend call, got %d", n)
+	}
+
+	// Age the cached file to 1 hour ago so the 30-minute TTL is exceeded.
+	stale := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(cachePath(fullURL), stale, stale); err != nil {
+		t.Fatalf("could not age cache file: %v", err)
+	}
+
+	// Second request: TTL exceeded, must re-fetch from remote.
+	w2 := httptest.NewRecorder()
+	handleGet(w2, httptest.NewRequest("GET", path, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second request: want 200, got %d", w2.Code)
+	}
+	if n := backendCalls.Load(); n != 2 {
+		t.Errorf("second request: want 2 backend calls (TTL expired), got %d", n)
+	}
+}
+
+// TestDefaultCacheTTLAppliedWhenNoRuleMatches verifies that when no caching
+// rule regex matches the requested URL the default TTL is used instead of any
+// rule's TTL.
+func TestDefaultCacheTTLAppliedWhenNoRuleMatches(t *testing.T) {
+	var backendCalls atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls.Add(1)
+		fmt.Fprint(w, "content")
+	}))
+	defer backend.Close()
+
+	// Rule only matches .rpm; request is for .txt, so default TTL (1h) applies.
+	config.CacheRules = map[string]CachingRules{
+		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "1ms", TTL: time.Millisecond},
+	}
+	t.Cleanup(func() { config.CacheRules = nil })
+
+	fullURL := "http://" + strings.TrimPrefix(backend.URL, "http://") + "/readme.txt"
+	path := "/" + strings.TrimPrefix(fullURL, "http://")
+
+	// First request: cache miss.
+	w1 := httptest.NewRecorder()
+	handleGet(w1, httptest.NewRequest("GET", path, nil))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first request: want 200, got %d", w1.Code)
+	}
+
+	// Age the file to 5 minutes ago. The 1ms .rpm rule would have expired but
+	// .txt doesn't match it; the default 1h TTL is still fresh.
+	stale := time.Now().Add(-5 * time.Minute)
+	if err := os.Chtimes(cachePath(fullURL), stale, stale); err != nil {
+		t.Fatalf("could not age cache file: %v", err)
+	}
+
+	// Second request: .txt misses the 1ms rule, default 1h TTL still fresh.
+	// Remote must not be called again.
+	w2 := httptest.NewRecorder()
+	handleGet(w2, httptest.NewRequest("GET", path, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second request: want 200, got %d", w2.Code)
+	}
+	if n := backendCalls.Load(); n != 1 {
+		t.Errorf("second request: want 1 backend call (default TTL, still fresh), got %d", n)
+	}
+}

--- a/helper.go
+++ b/helper.go
@@ -14,15 +14,17 @@ import (
 func handleError(response *http.Response, err error, w http.ResponseWriter) {
 	olo.Error("%s", err.Error())
 	if response != nil {
+		w.Header().Set("X-Pkgproxy-Error", fmt.Sprintf("remote returned HTTP %d", response.StatusCode))
 		w.WriteHeader(response.StatusCode)
-		bodyBytes, err := io.ReadAll(response.Body)
-		if err != nil {
+		bodyBytes, readErr := io.ReadAll(response.Body)
+		if readErr != nil {
 			olo.Error("Error while reading failed response body")
 		}
 		w.Write(bodyBytes)
 	} else {
+		w.Header().Set("X-Pkgproxy-Error", "remote-unreachable")
 		w.WriteHeader(500)
-		fmt.Fprint(w, err.Error())
+		fmt.Fprintf(w, "pkgproxy: could not reach the requested remote URL\n\nError: %s\n\nPlease check that the URL path is correct and the remote host is reachable from pkgproxy.\n", err.Error())
 	}
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleErrorNilResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+	handleError(nil, errors.New("dial tcp: lookup badhost.invalid: no such host"), w)
+
+	resp := w.Result()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status: want 500, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Pkgproxy-Error"); got != "remote-unreachable" {
+		t.Errorf("X-Pkgproxy-Error: want %q, got %q", "remote-unreachable", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "pkgproxy: could not reach the requested remote URL") {
+		t.Errorf("body missing helpful message, got: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "no such host") {
+		t.Errorf("body missing original error text, got: %s", bodyStr)
+	}
+}
+
+func TestHandleErrorWithResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+	fakeResp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("upstream: not found")),
+	}
+	handleError(fakeResp, errors.New("GET https://example.com/foo returned 404"), w)
+
+	resp := w.Result()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", resp.StatusCode)
+	}
+	want := "remote returned HTTP 404"
+	if got := resp.Header.Get("X-Pkgproxy-Error"); got != want {
+		t.Errorf("X-Pkgproxy-Error: want %q, got %q", want, got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "upstream: not found" {
+		t.Errorf("body: want upstream body forwarded, got: %s", body)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "pkgproxy-test-*")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cacheDir := filepath.Join(tmpDir, "cache")
+	cacheHTTPSDir := filepath.Join(tmpDir, "cache_https")
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		log.Fatal(err)
+	}
+	if err := os.MkdirAll(cacheHTTPSDir, 0755); err != nil {
+		log.Fatal(err)
+	}
+
+	config = &Config{
+		CacheFolder:            cacheDir,
+		CacheFolderHTTPS:       cacheHTTPSDir,
+		DefaultCacheTTL:        time.Hour,
+		MaxCacheItemSize:       100,
+		Timeout:                5,
+		PrometheusMetricPrefix: "test_",
+	}
+
+	client = &http.Client{Timeout: 5 * time.Second}
+
+	cache, err = CreateCache()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	initTestMetrics()
+
+	os.Exit(m.Run())
+}
+
+func initTestMetrics() {
+	promCounters = make(map[string]prometheus.Counter)
+	for _, name := range []string{
+		"TOTAL_REQUESTS", "REMOTE_ERRORS", "REMOTE_OK",
+		"TOTAL_HTTP_NONGET_REQUESTS", "TOTAL_HTTP_REQUESTS", "TOTAL_HTTPS_REQUESTS",
+		"CACHE_HIT", "CACHE_MISS", "CACHE_INVALIDATE", "CACHE_TOO_OLD",
+		"CACHE_OK", "CACHE_ITEM_MISSING",
+	} {
+		promCounters[name] = prometheus.NewCounter(prometheus.CounterOpts{Name: "test_noop"})
+	}
+	promSummaries = make(map[string]prometheus.Summary)
+	for _, name := range []string{"CACHE_READ_MEMORY", "CACHE_READ_FILE"} {
+		promSummaries[name] = prometheus.NewSummary(prometheus.SummaryOpts{Name: "test_noop"})
+	}
+}
+
+// TestHandleGetUnreachableHost exercises the full path through handleGet when
+// the remote cannot be reached (connection refused), verifying the error header and body.
+func TestHandleGetUnreachableHost(t *testing.T) {
+	// Start then immediately close a server so the port is not listening.
+	// A local address is used so the connection refused error comes back
+	// directly rather than being intercepted by any transparent proxy.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	srv.Close()
+
+	req := httptest.NewRequest("GET", "/"+addr+"/some/path", nil)
+	w := httptest.NewRecorder()
+	handleGet(w, req)
+
+	resp := w.Result()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status: want 500, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Pkgproxy-Error"); got != "remote-unreachable" {
+		t.Errorf("X-Pkgproxy-Error: want %q, got %q", "remote-unreachable", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "pkgproxy: could not reach the requested remote URL") {
+		t.Errorf("body missing helpful message, got: %s", body)
+	}
+}
+
+// TestHandleGetRemoteNonOKStatus exercises the path where the remote server
+// is reachable but returns a non-200 status, verifying the error header.
+func TestHandleGetRemoteNonOKStatus(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream not found", http.StatusNotFound)
+	}))
+	defer backend.Close()
+
+	// Strip scheme so the host:port becomes the first path segment,
+	// which handleGet interprets as the remote host to proxy to.
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/testfile"
+	req := httptest.NewRequest("GET", "/"+hostAndPath, nil)
+	w := httptest.NewRecorder()
+	handleGet(w, req)
+
+	resp := w.Result()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: want 404, got %d", resp.StatusCode)
+	}
+	want := "remote returned HTTP 404"
+	if got := resp.Header.Get("X-Pkgproxy-Error"); got != want {
+		t.Errorf("X-Pkgproxy-Error: want %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Problem

When a client requested a remote URL that pkgproxy could not reach (DNS failure, connection refused, or any other network-level error), the response was:

- HTTP 500 with a raw Go error string as the body (e.g. `Get "https://dl.rockylinux": dial tcp: lookup dl.rockylinux: no such host`)
- No header to distinguish the failure type
- No guidance on what went wrong or what to check

Example of the old behaviour:
```
HTTP/2 500
content-length: 48
content-type: text/plain; charset=utf-8
```

This made it hard to tell programmatically whether the 500 came from pkgproxy itself or was forwarded from an upstream server, and gave the user no actionable information.

## Changes

### [`helper.go`](https://github.com/xorpaul/pkgproxy/blob/ea2a08c73ec3b6ce69df3fd3443be45a2552ded1/helper.go)

Two cases are now handled distinctly in `handleError`:

**Network-level failure (nil response)** — the remote could not be reached at all:
- Header `X-Pkgproxy-Error: remote-unreachable` is set
- Body becomes a human-readable message that includes the original error and a hint to check the URL and remote reachability

**Upstream non-200 response (non-nil response)** — the remote was reached but returned an error status:
- Header `X-Pkgproxy-Error: remote returned HTTP <status>` is set
- Body and status code are forwarded unchanged from upstream (existing behaviour)

Headers are set before `WriteHeader()` so they are always transmitted. The incidental variable-shadowing bug (`err` reused inside the non-nil branch) was fixed as part of this change.

Example of the new behaviour for an unreachable host:
```
HTTP/2 500
x-pkgproxy-error: remote-unreachable
content-type: text/plain; charset=utf-8

pkgproxy: could not reach the requested remote URL

Error: Get "https://dl.rockylinux": dial tcp: lookup dl.rockylinux: no such host

Please check that the URL path is correct and the remote host is reachable from pkgproxy.
```

### Test files (new)

This PR adds the first test suite for pkgproxy. All tests are self-contained: `TestMain` in [`main_test.go`](https://github.com/xorpaul/pkgproxy/blob/3e8bea382de241cb279b67ce46290e293f092a22/main_test.go) wires up the required global state (config, cache, HTTP client, Prometheus counters) using a temporary directory, so `go test` requires no external setup.

**[`helper_test.go`](https://github.com/xorpaul/pkgproxy/blob/3e8bea382de241cb279b67ce46290e293f092a22/helper_test.go)** — unit tests for `handleError`:
- `TestHandleErrorNilResponse`: nil response → 500, `X-Pkgproxy-Error: remote-unreachable`, helpful body containing the original error
- `TestHandleErrorWithResponse`: non-nil response → status forwarded, `X-Pkgproxy-Error: remote returned HTTP 404`, upstream body forwarded

**[`main_test.go`](https://github.com/xorpaul/pkgproxy/blob/3e8bea382de241cb279b67ce46290e293f092a22/main_test.go)** — integration tests through `handleGet`:
- `TestHandleGetUnreachableHost`: starts then immediately closes a local test server so the port is not listening; uses a local address to avoid transparent-proxy interception; verifies 500 + `remote-unreachable` header + helpful body
- `TestHandleGetRemoteNonOKStatus`: live test server returning 404; verifies the status and `X-Pkgproxy-Error` header are forwarded correctly

**[`cache_test.go`](https://github.com/xorpaul/pkgproxy/blob/3e8bea382de241cb279b67ce46290e293f092a22/cache_test.go)** — caching rule behaviour, each driven against a local `httptest.Server` with an atomic backend-call counter:
- `TestCachingRuleServesFromCacheWhileFresh`: a URL matching a rule with a 1h TTL is served from cache on the second request; backend is called exactly once
- `TestCachingRuleRefreshesAfterExpiry`: after `os.Chtimes` ages the cached file past the rule's 30m TTL, the second request re-fetches from the remote; backend is called twice. `os.Chtimes` is used instead of `time.Sleep` to keep the test instantaneous and deterministic
- `TestDefaultCacheTTLAppliedWhenNoRuleMatches`: a URL that doesn't match any caching rule uses the default TTL (1h) rather than a rule's 1ms TTL; the item stays cached even after the rule's TTL would have expired

## Test plan

- [x] `go test ./...` passes (7 tests, ~15ms)
- [x] `curl -I https://pkgproxy.ionos.org/dl.rockylinux` returns `x-pkgproxy-error: remote-unreachable` and a readable body instead of a bare Go error string
- [x] A valid proxied URL still returns 200 and is cached as before
