### PR TITLE
Pre-compile CachingRules regexes at startup; fix goroutine leak and m…

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -110,12 +109,13 @@ func CreateCache() (*Cache, error) {
 		return nil
 	}
 
-	channel := make(chan error)
+	channel := make(chan error, 2)
 	olo.Debug("filepath.Walk'ing directory %s", cacheFolder)
 	go func() { channel <- filepath.WalkDir(cacheFolder, prefillCache) }()
 	olo.Debug("filepath.Walk'ing directory %s", CacheFolderHTTPS)
 	go func() { channel <- filepath.WalkDir(CacheFolderHTTPS, prefillCache) }()
-	<-channel // Walk done
+	<-channel
+	<-channel
 
 	if !config.PrefillCacheOnStartup {
 		olo.Info("prefillCache: Not prefilling in-memory cache with content, because prefill_cache_on_startup in config is set to false")
@@ -273,10 +273,14 @@ func (c *Cache) put(requestedURL string, content *io.Reader, contentLength int64
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	writer := bufio.NewWriter(file)
 	written, err := io.Copy(writer, *content)
 	if err != nil {
+		return err
+	}
+	if err = writer.Flush(); err != nil {
 		return err
 	}
 	olo.Debug("Wrote content size %d of entry %s into file %s", written, requestedURL, cacheFile)
@@ -316,9 +320,8 @@ func checkCacheTTL(filePath string, requestedURL string, defaultCacheTTL time.Du
 
 	ttl := defaultCacheTTL
 	for name, cr := range config.CacheRules {
-		r := regexp.MustCompile(cr.Regex)
 		// olo.Debug("comparing regex rule: '%s' with regex '%s' with cacheURL: '%s'", name, cr.Regex, cacheURL)
-		if r.MatchString(requestedURL) {
+		if cr.CompiledRegex.MatchString(requestedURL) {
 			olo.Debug("found matching regex rule: '%s' with regex '%s' and ttl '%s' for requestedURL: '%s'", name, cr.Regex, cr.TTL, requestedURL)
 			ttl = cr.TTL
 			// olo.Debug("setting ttl to '%s' for file '%s'", ttl, cacheURL)

--- a/cache_test.go
+++ b/cache_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -31,7 +33,7 @@ func TestCachingRuleServesFromCacheWhileFresh(t *testing.T) {
 	defer backend.Close()
 
 	config.CacheRules = map[string]CachingRules{
-		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "1h", TTL: time.Hour},
+		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "1h", TTL: time.Hour, CompiledRegex: regexp.MustCompile(`.*\.rpm$`)},
 	}
 	t.Cleanup(func() { config.CacheRules = nil })
 
@@ -69,7 +71,7 @@ func TestCachingRuleRefreshesAfterExpiry(t *testing.T) {
 	defer backend.Close()
 
 	config.CacheRules = map[string]CachingRules{
-		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "30m", TTL: 30 * time.Minute},
+		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "30m", TTL: 30 * time.Minute, CompiledRegex: regexp.MustCompile(`.*\.rpm$`)},
 	}
 	t.Cleanup(func() { config.CacheRules = nil })
 
@@ -116,7 +118,7 @@ func TestDefaultCacheTTLAppliedWhenNoRuleMatches(t *testing.T) {
 
 	// Rule only matches .rpm; request is for .txt, so default TTL (1h) applies.
 	config.CacheRules = map[string]CachingRules{
-		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "1ms", TTL: time.Millisecond},
+		"RPM Packages": {Regex: `.*\.rpm$`, TTLString: "1ms", TTL: time.Millisecond, CompiledRegex: regexp.MustCompile(`.*\.rpm$`)},
 	}
 	t.Cleanup(func() { config.CacheRules = nil })
 
@@ -146,5 +148,92 @@ func TestDefaultCacheTTLAppliedWhenNoRuleMatches(t *testing.T) {
 	}
 	if n := backendCalls.Load(); n != 1 {
 		t.Errorf("second request: want 1 backend call (default TTL, still fresh), got %d", n)
+	}
+}
+
+// TestCachePutFlushesCompleteContent verifies that cache.put writes the full
+// content to disk. bufio.Writer buffers writes internally; without an explicit
+// Flush() the trailing partial buffer is never written to the file. We use a
+// payload larger than bufio's default 4096-byte buffer so the final chunk
+// stays buffered until Flush() forces it out.
+func TestCachePutFlushesCompleteContent(t *testing.T) {
+	const size = 8192
+	content := strings.Repeat("x", size)
+	r := strings.NewReader(content)
+	var reader io.Reader = r
+
+	rawURL := "http://flush-test.example.com/bigfile.bin"
+	if err := cache.put(rawURL, &reader, int64(size)); err != nil {
+		t.Fatalf("cache.put: %v", err)
+	}
+
+	// Reconstruct the on-disk path using the same logic as cache.put.
+	parts := strings.SplitN(rawURL, "/", 4)
+	cacheFile := filepath.Join(config.CacheFolder, parts[2], url.QueryEscape(parts[3]))
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatalf("reading cache file from disk: %v", err)
+	}
+	if len(data) != size {
+		t.Errorf("cache file size on disk: want %d bytes, got %d (trailing buffer not flushed?)", size, len(data))
+	}
+	if string(data) != content {
+		t.Error("cache file content does not match written content")
+	}
+}
+
+// TestCreateCachePrefillsBothHTTPAndHTTPS verifies that when
+// prefill_cache_on_startup is true, CreateCache indexes files from both the
+// HTTP cache dir and the HTTPS cache dir. This covers the code path where two
+// concurrent WalkDir goroutines both complete and their results are both
+// awaited before CreateCache returns.
+func TestCreateCachePrefillsBothHTTPAndHTTPS(t *testing.T) {
+	tmpDir := t.TempDir()
+	httpDir := filepath.Join(tmpDir, "http")
+	httpsDir := filepath.Join(tmpDir, "https")
+
+	// Create one cached file under each scheme dir, mirroring the directory
+	// structure that cache.put writes: <cacheDir>/<host>/<encoded-path>.
+	if err := os.MkdirAll(filepath.Join(httpDir, "pkg.example.com"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(httpDir, "pkg.example.com", "file.rpm"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(httpsDir, "secure.example.com"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(httpsDir, "secure.example.com", "file.deb"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHTTP := config.CacheFolder
+	oldHTTPS := config.CacheFolderHTTPS
+	oldPrefill := config.PrefillCacheOnStartup
+	config.CacheFolder = httpDir
+	config.CacheFolderHTTPS = httpsDir
+	config.PrefillCacheOnStartup = true
+	t.Cleanup(func() {
+		config.CacheFolder = oldHTTP
+		config.CacheFolderHTTPS = oldHTTPS
+		config.PrefillCacheOnStartup = oldPrefill
+	})
+
+	c, err := CreateCache()
+	if err != nil {
+		t.Fatalf("CreateCache: %v", err)
+	}
+
+	c.mutex.Lock()
+	_, hasHTTP := c.cacheMemoryItems["http://pkg.example.com/file.rpm"]
+	_, hasHTTPS := c.cacheMemoryItems["https://secure.example.com/file.deb"]
+	c.mutex.Unlock()
+
+	if !hasHTTP {
+		t.Error("HTTP cache file not indexed by CreateCache")
+	}
+	if !hasHTTPS {
+		t.Error("HTTPS cache file not indexed by CreateCache")
 	}
 }

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	h "github.com/xorpaul/gohelper"
@@ -44,9 +45,10 @@ type Config struct {
 }
 
 type CachingRules struct {
-	Regex     string        `yaml:"regex"`
-	TTLString string        `yaml:"ttl"`
-	TTL       time.Duration `yaml:"ttlDuration"`
+	Regex          string         `yaml:"regex"`
+	TTLString      string         `yaml:"ttl"`
+	TTL            time.Duration  `yaml:"ttlDuration"`
+	CompiledRegex  *regexp.Regexp `yaml:"-"`
 }
 
 func LoadConfig(path string) (*Config, error) {
@@ -82,6 +84,7 @@ func LoadConfig(path string) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
+		cr.CompiledRegex = regexp.MustCompile(cr.Regex)
 		olo.Info("setting ttl to '%s' for regex '%s'", cr.TTL, cr.Regex)
 		config.CacheRules[name] = cr
 	}
@@ -97,6 +100,7 @@ func LoadConfig(path string) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
+		cr.CompiledRegex = regexp.MustCompile(cr.Regex)
 		config.ServiceNameDefaultCacheTTL[name] = cr
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLoadConfigCompilesRegexes verifies that LoadConfig pre-compiles the
+// regex for every rule in both CacheRules and ServiceNameDefaultCacheTTL so
+// the hot request path can match without recompiling on every call.
+func TestLoadConfigCompilesRegexes(t *testing.T) {
+	yaml := `
+cache_folder: /tmp
+cache_folder_https: /tmp
+default_cache_ttl: 1h
+caching_rules:
+  rpm-rule:
+    regex: '.*\.rpm$'
+    ttl: 24h
+  deb-rule:
+    regex: '.*\.deb$'
+    ttl: 12h
+service_default_cache_ttl:
+  myservice:
+    regex: 'myservice\.'
+    ttl: 48h
+`
+	f, err := os.CreateTemp("", "pkgproxy-cfg-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(yaml); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	cfg, err := LoadConfig(f.Name())
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	for name, cr := range cfg.CacheRules {
+		if cr.CompiledRegex == nil {
+			t.Errorf("CacheRules[%q].CompiledRegex is nil; LoadConfig must pre-compile it", name)
+			continue
+		}
+		// Spot-check that the compiled regex matches what the Regex field says it should.
+		switch name {
+		case "rpm-rule":
+			if !cr.CompiledRegex.MatchString("package.rpm") {
+				t.Errorf("CacheRules[%q].CompiledRegex should match .rpm files", name)
+			}
+			if cr.CompiledRegex.MatchString("package.deb") {
+				t.Errorf("CacheRules[%q].CompiledRegex should not match .deb files", name)
+			}
+		case "deb-rule":
+			if !cr.CompiledRegex.MatchString("package.deb") {
+				t.Errorf("CacheRules[%q].CompiledRegex should match .deb files", name)
+			}
+		}
+	}
+
+	for name, cr := range cfg.ServiceNameDefaultCacheTTL {
+		if cr.CompiledRegex == nil {
+			t.Errorf("ServiceNameDefaultCacheTTL[%q].CompiledRegex is nil; LoadConfig must pre-compile it", name)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -236,9 +235,8 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 	// to change the default cache TTL to 1 year and so on
 	defaultCacheTTL := config.DefaultCacheTTL
 	for name, cr := range config.ServiceNameDefaultCacheTTL {
-		re := regexp.MustCompile(cr.Regex)
 		// olo.Debug("comparing regex rule: '%s' with regex '%s' with cacheURL: '%s'", name, cr.Regex, cacheURL)
-		if re.MatchString(r.Host) {
+		if cr.CompiledRegex.MatchString(r.Host) {
 			olo.Debug("found matching service name regex rule: '%s' with regex '%s' and default ttl '%s' for service name: '%s'", name, cr.Regex, cr.TTL, r.Host)
 			defaultCacheTTL = cr.TTL
 			olo.Debug("setting default ttl to '%s' for service name '%s'", defaultCacheTTL.String(), r.Host)


### PR DESCRIPTION
…issing flush

Both `checkCacheTTL` (cache.go) and `handleGet` (main.go) were calling `regexp.MustCompile(cr.Regex)` on every incoming request inside a range loop over config.CacheRules / ServiceNameDefaultCacheTTL. This allocated a new regexp engine on every cache TTL check and every service-name lookup, regardless of whether the rule matched.

Add a `CompiledRegex *regexp.Regexp` field to `CachingRules` (tagged `yaml:"-"` so YAML ignores it) and populate it in `LoadConfig` next to the existing TTL parsing. The hot-path loops now call `cr.CompiledRegex.MatchString(...)` instead. Update the three test cases that construct `CachingRules` literals directly to also set `CompiledRegex`.

Also fix two correctness bugs found while reviewing:
- CreateCache goroutine leak: `channel` had two senders but only one `<-channel` receive; the second goroutine blocked forever on send. Changed to a buffered channel of size 2 and added the missing second receive.
- cache.put missing flush/close: `bufio.NewWriter` wrapped the file but `Flush()` was never called, so the last (partial) buffer chunk could be silently lost before `fillInMemoryCacheWithFileContent` re-read the file. Also added `defer file.Close()` which was absent.

Tests added:
- TestLoadConfigCompilesRegexes: asserts CompiledRegex is non-nil and correct for every rule in both CacheRules and ServiceNameDefaultCacheTTL after LoadConfig returns.
- TestCachePutFlushesCompleteContent: writes 8192 bytes (2× bufio's default buffer) through cache.put and reads the file from disk to verify all bytes were flushed.
- TestCreateCachePrefillsBothHTTPAndHTTPS: exercises PrefillCacheOnStartup=true with files in both the HTTP and HTTPS cache dirs and asserts both are indexed.