### PR TITLE
Return 404 for PATCH requests on non-cached items

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -240,6 +240,14 @@ func (c *Cache) get(requestedURL string, defaultCacheTTL time.Duration, invalida
 
 }
 
+// cancelBusy removes the busy lock for requestedURL without caching the item.
+// The busy lock *must* be unlocked elsewhere!
+func (c *Cache) cancelBusy(requestedURL string) {
+	c.mutex.Lock()
+	delete(c.busyItems, requestedURL)
+	c.mutex.Unlock()
+}
+
 // release is an internal method which atomically caches an item and unmarks
 // the item as busy, if it was busy before. The busy lock *must* be unlocked
 // elsewhere!

--- a/main.go
+++ b/main.go
@@ -303,6 +303,13 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 	if busy, ok := cache.has(fullUrl); !ok {
 		olo.Info("CACHE_MISS for requested '%s'", fullUrl)
 		promCounters["CACHE_MISS"].Inc()
+		if r.Method == "PATCH" {
+			olo.Info("PATCH request for non-cached item '%s' - returning 404", fullUrl)
+			cache.cancelBusy(fullUrl)
+			busy.Unlock()
+			http.Error(w, "Cache item not found", http.StatusNotFound)
+			return
+		}
 		defer busy.Unlock()
 		response, err := GetRemote(fullUrl)
 		if err != nil {
@@ -314,10 +321,7 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 		promCounters["CACHE_HIT"].Inc()
 	}
 
-	invalidateCache := false
-	if r.Method == "PATCH" {
-		invalidateCache = true
-	}
+	invalidateCache := r.Method == "PATCH"
 
 	// The cache has definitely the data we want, so get a reader for that
 	cacheResponse, err := cache.get(fullUrl, defaultCacheTTL, invalidateCache)

--- a/main_test.go
+++ b/main_test.go
@@ -95,6 +95,78 @@ func TestHandleGetUnreachableHost(t *testing.T) {
 	}
 }
 
+// TestPatchNonCachedItem verifies that a PATCH request for an item not yet in
+// the cache returns 404 without attempting a download.
+func TestPatchNonCachedItem(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("backend should not be contacted for PATCH on non-cached item")
+	}))
+	defer backend.Close()
+
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/never-cached-file"
+	req := httptest.NewRequest("PATCH", "/"+hostAndPath, nil)
+	w := httptest.NewRecorder()
+	handleGet(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: want 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestPatchCachedItem verifies that a PATCH request for an item already in the
+// cache triggers a re-download (cache invalidation) and returns 200. A
+// subsequent GET must return the refreshed content.
+func TestPatchCachedItem(t *testing.T) {
+	const firstContent = "original content"
+	const secondContent = "refreshed content"
+	callCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.Write([]byte(firstContent))
+		} else {
+			w.Write([]byte(secondContent))
+		}
+	}))
+	defer backend.Close()
+
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/patch-test-file"
+
+	// Prime the cache with a GET.
+	getReq := httptest.NewRequest("GET", "/"+hostAndPath, nil)
+	getW := httptest.NewRecorder()
+	handleGet(getW, getReq)
+	if getW.Result().StatusCode != http.StatusOK {
+		t.Fatalf("initial GET status: want 200, got %d", getW.Result().StatusCode)
+	}
+
+	// PATCH should invalidate and trigger a re-download (2nd backend call).
+	patchReq := httptest.NewRequest("PATCH", "/"+hostAndPath, nil)
+	patchW := httptest.NewRecorder()
+	handleGet(patchW, patchReq)
+
+	if patchW.Result().StatusCode != http.StatusOK {
+		t.Fatalf("PATCH status: want 200, got %d", patchW.Result().StatusCode)
+	}
+	if callCount != 2 {
+		t.Errorf("backend call count after PATCH: want 2, got %d", callCount)
+	}
+
+	// A subsequent GET must serve the refreshed content from cache without
+	// hitting the backend again.
+	getReq2 := httptest.NewRequest("GET", "/"+hostAndPath, nil)
+	getW2 := httptest.NewRecorder()
+	handleGet(getW2, getReq2)
+	body, _ := io.ReadAll(getW2.Result().Body)
+	if !strings.Contains(string(body), secondContent) {
+		t.Errorf("GET after PATCH: want %q in body, got %q", secondContent, string(body))
+	}
+	if callCount != 2 {
+		t.Errorf("backend call count after GET: want still 2, got %d", callCount)
+	}
+}
+
 // TestHandleGetRemoteNonOKStatus exercises the path where the remote server
 // is reachable but returns a non-200 status, verifying the error header.
 func TestHandleGetRemoteNonOKStatus(t *testing.T) {


### PR DESCRIPTION
Fixes #22.

## Problem

`PATCH` is used to force cache invalidation. When a CI/CD pipeline sends PATCH requests to invalidate repository metadata (e.g. all paths listed in a Debian `Release` file), pkgproxy was unconditionally downloading and caching every file it received a PATCH for — including architectures like `sparc` and `armel` that no pipeline ever fetches. This wasted bandwidth and disk I/O on content that would never be served.

## Solution

If a PATCH arrives for a URL that is **not already in the cache**, pkgproxy now returns `HTTP 404` immediately without contacting the upstream server. Only URLs that are already cached get invalidated and re-downloaded, which is the intended use case.

If a PATCH arrives for a URL that **is** in cache, behaviour is unchanged: the cache entry is invalidated and a fresh copy is fetched from upstream.

## Changes

**[`cache.go:245`](https://github.com/xorpaul/pkgproxy/blob/only_redownload_if_cache_item_exists/cache.go#L245)** — new `cancelBusy()` method: removes the busy-lock entry from `busyItems` without populating `cacheMemoryItems`. This is the counterpart to `release()` for the abort-without-caching case; the busy mutex itself is still unlocked by the caller, consistent with how `release()` works.

**[`main.go:306–312`](https://github.com/xorpaul/pkgproxy/blob/only_redownload_if_cache_item_exists/main.go#L306)** — in the cache-miss branch of `handleGet`, a PATCH request calls `cancelBusy`, unlocks the busy mutex, and returns 404. Execution never reaches `GetRemote`.

**[`main.go:324`](https://github.com/xorpaul/pkgproxy/blob/only_redownload_if_cache_item_exists/main.go#L324)** — simplified `invalidateCache` assignment to a one-liner (`r.Method == "PATCH"`).

## Tests

Two new tests in `main_test.go`:

- **`TestPatchNonCachedItem`** — PATCH on an uncached URL returns 404; the backend handler asserts it is never contacted.
- **`TestPatchCachedItem`** — PATCH on a previously cached URL returns 200, the backend is contacted exactly twice (initial GET + invalidation re-fetch), and a subsequent GET returns the refreshed content without a third backend call.

## Test plan

- [x] `go test ./...` passes
- [x] PATCH on a URL that has never been requested returns 404 and the upstream server sees no request
- [x] PATCH on a previously cached URL returns 200 and a subsequent GET serves the refreshed content
