### PR TITLE
Add negative caching for 404 responses

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -20,6 +20,7 @@ import (
 type Cache struct {
 	busyItems        map[string]*sync.Mutex
 	cacheMemoryItems map[string]CacheMemoryItem
+	notFoundItems    map[string]time.Time
 	mutex            *sync.Mutex
 }
 
@@ -48,6 +49,7 @@ func CreateCache() (*Cache, error) {
 	mutex := &sync.Mutex{}
 	busy := make(map[string]*sync.Mutex)
 	memory := make(map[string]CacheMemoryItem)
+	notFound := make(map[string]time.Time)
 
 	// Go through every file an save its name in the map. The content of the file
 	// is loaded when needed. This makes sure that we don't have to read
@@ -66,6 +68,27 @@ func CreateCache() (*Cache, error) {
 			urlScheme = "https://"
 			cfTrim = CacheFolderHTTPS
 		}
+
+		// Negative-cache sentinel files: restore notFoundItems from disk.
+		if strings.HasSuffix(d.Name(), ".404") {
+			fi, fiErr := d.Info()
+			if fiErr != nil {
+				return nil
+			}
+			itemPath := strings.TrimSuffix(strings.TrimPrefix(path, cfTrim), ".404")
+			itemPath, err = url.QueryUnescape(itemPath)
+			if err != nil {
+				olo.Fatal("While url decode .404 sentinel file %s Error: %s", path, err.Error())
+				return err
+			}
+			itemURL := urlScheme + itemPath
+			mutex.Lock()
+			notFound[itemURL] = fi.ModTime()
+			mutex.Unlock()
+			olo.Debug("prefillCache: restored negative cache entry for %s (mtime %s)", itemURL, fi.ModTime())
+			return nil
+		}
+
 		cachedItem := strings.TrimPrefix(path, cfTrim)
 		cachedItem, err = url.QueryUnescape(cachedItem)
 		if err != nil {
@@ -130,6 +153,7 @@ func CreateCache() (*Cache, error) {
 		busyItems:        busy,
 		mutex:            mutex,
 		cacheMemoryItems: memory,
+		notFoundItems:    notFound,
 	}
 
 	return cache, nil
@@ -366,6 +390,78 @@ func checkCacheTTL(filePath string, requestedURL string, defaultCacheTTL time.Du
 	olo.Info("CACHE_OK until '%s'/'%s' for requested URL '%s'", time.Until(validUntil), validUntil.Format("2006-01-02 15:04:05"), requestedURL)
 	promCounters["CACHE_OK"].Inc()
 	return nil
+}
+
+func (c *Cache) negativeCacheTTL(requestedURL string) time.Duration {
+	for _, rule := range config.NegativeCacheRules {
+		if rule.CompiledRegex.MatchString(requestedURL) {
+			return rule.TTL
+		}
+	}
+	return config.NegativeCacheTTL
+}
+
+func (c *Cache) isNotFound(requestedURL string) bool {
+	c.mutex.Lock()
+	t, ok := c.notFoundItems[requestedURL]
+	c.mutex.Unlock()
+	if !ok {
+		return false
+	}
+	if time.Since(t) > c.negativeCacheTTL(requestedURL) {
+		c.deleteNotFoundEntry(requestedURL)
+		return false
+	}
+	return true
+}
+
+func (c *Cache) putNotFound(requestedURL string) error {
+	cacheFolder := config.CacheFolder
+	if strings.HasPrefix(requestedURL, "https://") {
+		cacheFolder = config.CacheFolderHTTPS
+	}
+	urlParts := strings.SplitN(requestedURL, "/", 4)
+	if len(urlParts) < 4 {
+		return fmt.Errorf("invalid URL for negative cache: %s", requestedURL)
+	}
+	fileCacheDir := filepath.Join(cacheFolder, urlParts[2])
+	if _, err := h.CheckDirAndCreate(fileCacheDir, "Cache.putNotFound"); err != nil {
+		return err
+	}
+	sentinelFile := filepath.Join(fileCacheDir, url.QueryEscape(urlParts[3])+".404")
+
+	f, err := os.Create(sentinelFile)
+	if err != nil {
+		return err
+	}
+	f.Close()
+
+	now := time.Now()
+	c.mutex.Lock()
+	c.notFoundItems[requestedURL] = now
+	c.mutex.Unlock()
+	return nil
+}
+
+// deleteNotFoundEntry removes a negative cache entry from memory and deletes
+// its sentinel file from disk (best-effort).
+func (c *Cache) deleteNotFoundEntry(requestedURL string) {
+	c.mutex.Lock()
+	delete(c.notFoundItems, requestedURL)
+	c.mutex.Unlock()
+
+	cacheFolder := config.CacheFolder
+	if strings.HasPrefix(requestedURL, "https://") {
+		cacheFolder = config.CacheFolderHTTPS
+	}
+	urlParts := strings.SplitN(requestedURL, "/", 4)
+	if len(urlParts) < 4 {
+		return
+	}
+	sentinelFile := filepath.Join(cacheFolder, urlParts[2], url.QueryEscape(urlParts[3])+".404")
+	if err := os.Remove(sentinelFile); err != nil && !os.IsNotExist(err) {
+		olo.Debug("could not remove expired .404 sentinel %s: %s", sentinelFile, err)
+	}
 }
 
 func (c *Cache) fillInMemoryCacheWithFileContent(file string, requestedURL string) error {

--- a/cache.go
+++ b/cache.go
@@ -401,18 +401,21 @@ func (c *Cache) negativeCacheTTL(requestedURL string) time.Duration {
 	return config.NegativeCacheTTL
 }
 
-func (c *Cache) isNotFound(requestedURL string) bool {
+// isNotFound returns (true, expiry) when requestedURL is in the negative cache
+// and its TTL has not yet elapsed. Returns (false, zero) otherwise.
+func (c *Cache) isNotFound(requestedURL string) (bool, time.Time) {
 	c.mutex.Lock()
 	t, ok := c.notFoundItems[requestedURL]
 	c.mutex.Unlock()
 	if !ok {
-		return false
+		return false, time.Time{}
 	}
-	if time.Since(t) > c.negativeCacheTTL(requestedURL) {
+	expiry := t.Add(c.negativeCacheTTL(requestedURL))
+	if time.Now().After(expiry) {
 		c.deleteNotFoundEntry(requestedURL)
-		return false
+		return false, time.Time{}
 	}
-	return true
+	return true, expiry
 }
 
 func (c *Cache) putNotFound(requestedURL string) error {

--- a/config.go
+++ b/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	ServiceNameDefaultCacheTTL map[string]CachingRules `yaml:"service_default_cache_ttl"`
 	MaxCacheItemSize           int64                   `yaml:"max_cache_item_size_in_mb"`
 	CacheRules                 map[string]CachingRules `yaml:"caching_rules"`
+	NegativeCacheTTLString     string                  `yaml:"negative_cache_ttl"`
+	NegativeCacheTTL           time.Duration
+	NegativeCacheRules         map[string]CachingRules `yaml:"negative_caching_rules"`
 	ReturnCacheIfRemoteFails   bool                    `yaml:"return_cache_if_remote_fails"`
 	PrometheusMetricPrefix     string                  `yaml:"prometheus_metric_prefix"`
 	ListenAddressPrometheus    string                  `yaml:"listen_address_prometheus"`
@@ -92,6 +95,24 @@ func LoadConfig(path string) (*Config, error) {
 	config.DefaultCacheTTL, err = time.ParseDuration(config.DefaultCacheTTLString)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.NegativeCacheTTLString != "" {
+		config.NegativeCacheTTL, err = time.ParseDuration(config.NegativeCacheTTLString)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for name, cr := range config.NegativeCacheRules {
+		olo.Info("adding negative caching rule '%s': regex:'%s' ttl:'%s'", name, cr.Regex, cr.TTLString)
+		cr.TTL, err = time.ParseDuration(cr.TTLString)
+		if err != nil {
+			return nil, err
+		}
+		cr.CompiledRegex = regexp.MustCompile(cr.Regex)
+		olo.Info("setting negative cache ttl to '%s' for regex '%s'", cr.TTL, cr.Regex)
+		config.NegativeCacheRules[name] = cr
 	}
 
 	for name, cr := range config.ServiceNameDefaultCacheTTL {

--- a/example.yaml
+++ b/example.yaml
@@ -32,3 +32,14 @@ caching_rules:
   RPM Packages:
     regex: '.*\.rpm$'
     ttl: 8544h # 1 year
+# Cache 404 responses to avoid hammering upstream with repeated requests for
+# URLs that don't exist (e.g. EOL distro repos, missing translation files).
+# PATCH requests invalidate negative cache entries, same as positive cache.
+#negative_cache_ttl: 1h
+#negative_caching_rules:
+#  EOL Debian archive:
+#    regex: 'archive\.debian\.org/.*'
+#    ttl: 24h
+#  EOL nginx jessie:
+#    regex: 'nginx\.org/packages/debian/dists/jessie/.*'
+#    ttl: 168h # 1 week

--- a/main.go
+++ b/main.go
@@ -312,18 +312,24 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// PATCH always clears any negative cache entry so the next GET re-fetches upstream.
-	if r.Method == "PATCH" && config.NegativeCacheTTL > 0 && cache.isNotFound(fullUrl) {
-		cache.deleteNotFoundEntry(fullUrl)
-		olo.Info("NEGATIVE_CACHE_INVALIDATE via PATCH for '%s'", fullUrl)
-		promCounters["NEGATIVE_CACHE_INVALIDATE"].Inc()
+	if r.Method == "PATCH" && config.NegativeCacheTTL > 0 {
+		if found, _ := cache.isNotFound(fullUrl); found {
+			cache.deleteNotFoundEntry(fullUrl)
+			olo.Info("NEGATIVE_CACHE_INVALIDATE via PATCH for '%s'", fullUrl)
+			promCounters["NEGATIVE_CACHE_INVALIDATE"].Inc()
+		}
 	}
 
 	// Fast path: URL is known to return 404, serve from negative cache (skip for PATCH).
-	if r.Method != "PATCH" && config.NegativeCacheTTL > 0 && cache.isNotFound(fullUrl) {
-		olo.Info("NEGATIVE_CACHE_HIT for '%s'", fullUrl)
-		promCounters["NEGATIVE_CACHE_HIT"].Inc()
-		http.Error(w, "File not found", http.StatusNotFound)
-		return
+	if r.Method != "PATCH" && config.NegativeCacheTTL > 0 {
+		if found, expiry := cache.isNotFound(fullUrl); found {
+			olo.Info("NEGATIVE_CACHE_HIT for '%s'", fullUrl)
+			promCounters["NEGATIVE_CACHE_HIT"].Inc()
+			w.Header().Set("X-Pkgproxy-Negative-Cache", "HIT")
+			w.Header().Set("X-Pkgproxy-Cache-Expires", expiry.UTC().Format(time.RFC3339))
+			http.Error(w, "File not found", http.StatusNotFound)
+			return
+		}
 	}
 
 	// Cache miss -> Load data from requested URL and add to cache
@@ -339,13 +345,17 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 		}
 		// Re-check after waiting in has() — handles concurrent requests for a
 		// URL that was just 404'd and stored in the negative cache by another goroutine.
-		if config.NegativeCacheTTL > 0 && cache.isNotFound(fullUrl) {
-			cache.cancelBusy(fullUrl)
-			busy.Unlock()
-			olo.Info("NEGATIVE_CACHE_HIT for '%s'", fullUrl)
-			promCounters["NEGATIVE_CACHE_HIT"].Inc()
-			http.Error(w, "File not found", http.StatusNotFound)
-			return
+		if config.NegativeCacheTTL > 0 {
+			if found, expiry := cache.isNotFound(fullUrl); found {
+				cache.cancelBusy(fullUrl)
+				busy.Unlock()
+				olo.Info("NEGATIVE_CACHE_HIT for '%s'", fullUrl)
+				promCounters["NEGATIVE_CACHE_HIT"].Inc()
+				w.Header().Set("X-Pkgproxy-Negative-Cache", "HIT")
+				w.Header().Set("X-Pkgproxy-Cache-Expires", expiry.UTC().Format(time.RFC3339))
+				http.Error(w, "File not found", http.StatusNotFound)
+				return
+			}
 		}
 		defer busy.Unlock()
 		response, err := GetRemote(fullUrl)
@@ -357,6 +367,9 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 				}
 				olo.Info("NEGATIVE_CACHE_PUT for '%s'", fullUrl)
 				promCounters["NEGATIVE_CACHE_PUT"].Inc()
+				expiry := time.Now().Add(cache.negativeCacheTTL(fullUrl))
+				w.Header().Set("X-Pkgproxy-Error", "remote returned HTTP 404")
+				w.Header().Set("X-Pkgproxy-Cache-Expires", expiry.UTC().Format(time.RFC3339))
 				http.Error(w, "File not found", http.StatusNotFound)
 			} else {
 				handleError(response, err, w)

--- a/main.go
+++ b/main.go
@@ -193,6 +193,18 @@ func prepare() {
 		Name: config.PrometheusMetricPrefix + "pkgproxy_cache_item_missing_total",
 		Help: "Cache item was known while starting the service, but was removed afterwards, this should really be 0 otherwise something is seriously wrong",
 	})
+	promCounters["NEGATIVE_CACHE_HIT"] = promauto.NewCounter(prometheus.CounterOpts{
+		Name: config.PrometheusMetricPrefix + "pkgproxy_negative_cache_hit_total",
+		Help: "The total number of requests served directly from negative cache (upstream returned 404 previously)",
+	})
+	promCounters["NEGATIVE_CACHE_PUT"] = promauto.NewCounter(prometheus.CounterOpts{
+		Name: config.PrometheusMetricPrefix + "pkgproxy_negative_cache_put_total",
+		Help: "The total number of 404 responses stored in the negative cache",
+	})
+	promCounters["NEGATIVE_CACHE_INVALIDATE"] = promauto.NewCounter(prometheus.CounterOpts{
+		Name: config.PrometheusMetricPrefix + "pkgproxy_negative_cache_invalidate_total",
+		Help: "The total number of negative cache entries cleared by PATCH requests",
+	})
 
 	promSummaries = make(map[string]prometheus.Summary)
 	promSummaries["CACHE_READ_MEMORY"] = promauto.NewSummary(prometheus.SummaryOpts{
@@ -299,6 +311,21 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 		promCounters[requestedFQDN].Inc()
 	}
 
+	// PATCH always clears any negative cache entry so the next GET re-fetches upstream.
+	if r.Method == "PATCH" && config.NegativeCacheTTL > 0 && cache.isNotFound(fullUrl) {
+		cache.deleteNotFoundEntry(fullUrl)
+		olo.Info("NEGATIVE_CACHE_INVALIDATE via PATCH for '%s'", fullUrl)
+		promCounters["NEGATIVE_CACHE_INVALIDATE"].Inc()
+	}
+
+	// Fast path: URL is known to return 404, serve from negative cache (skip for PATCH).
+	if r.Method != "PATCH" && config.NegativeCacheTTL > 0 && cache.isNotFound(fullUrl) {
+		olo.Info("NEGATIVE_CACHE_HIT for '%s'", fullUrl)
+		promCounters["NEGATIVE_CACHE_HIT"].Inc()
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
+	}
+
 	// Cache miss -> Load data from requested URL and add to cache
 	if busy, ok := cache.has(fullUrl); !ok {
 		olo.Info("CACHE_MISS for requested '%s'", fullUrl)
@@ -310,10 +337,30 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Cache item not found", http.StatusNotFound)
 			return
 		}
+		// Re-check after waiting in has() — handles concurrent requests for a
+		// URL that was just 404'd and stored in the negative cache by another goroutine.
+		if config.NegativeCacheTTL > 0 && cache.isNotFound(fullUrl) {
+			cache.cancelBusy(fullUrl)
+			busy.Unlock()
+			olo.Info("NEGATIVE_CACHE_HIT for '%s'", fullUrl)
+			promCounters["NEGATIVE_CACHE_HIT"].Inc()
+			http.Error(w, "File not found", http.StatusNotFound)
+			return
+		}
 		defer busy.Unlock()
 		response, err := GetRemote(fullUrl)
 		if err != nil {
-			handleError(response, err, w)
+			cache.cancelBusy(fullUrl)
+			if response != nil && response.StatusCode == http.StatusNotFound && config.NegativeCacheTTL > 0 {
+				if nerr := cache.putNotFound(fullUrl); nerr != nil {
+					olo.Error("putNotFound failed for %s: %s", fullUrl, nerr)
+				}
+				olo.Info("NEGATIVE_CACHE_PUT for '%s'", fullUrl)
+				promCounters["NEGATIVE_CACHE_PUT"].Inc()
+				http.Error(w, "File not found", http.StatusNotFound)
+			} else {
+				handleError(response, err, w)
+			}
 			return
 		}
 	} else {

--- a/main_test.go
+++ b/main_test.go
@@ -7,12 +7,17 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+func mustCompileRegex(s string) *regexp.Regexp {
+	return regexp.MustCompile(s)
+}
 
 func TestMain(m *testing.M) {
 	tmpDir, err := os.MkdirTemp("", "pkgproxy-test-*")
@@ -58,6 +63,7 @@ func initTestMetrics() {
 		"TOTAL_HTTP_NONGET_REQUESTS", "TOTAL_HTTP_REQUESTS", "TOTAL_HTTPS_REQUESTS",
 		"CACHE_HIT", "CACHE_MISS", "CACHE_INVALIDATE", "CACHE_TOO_OLD",
 		"CACHE_OK", "CACHE_ITEM_MISSING",
+		"NEGATIVE_CACHE_HIT", "NEGATIVE_CACHE_PUT", "NEGATIVE_CACHE_INVALIDATE",
 	} {
 		promCounters[name] = prometheus.NewCounter(prometheus.CounterOpts{Name: "test_noop"})
 	}
@@ -190,5 +196,170 @@ func TestHandleGetRemoteNonOKStatus(t *testing.T) {
 	want := "remote returned HTTP 404"
 	if got := resp.Header.Get("X-Pkgproxy-Error"); got != want {
 		t.Errorf("X-Pkgproxy-Error: want %q, got %q", want, got)
+	}
+}
+
+// TestNegativeCacheStopsUpstreamHits verifies that after a 404 is stored in
+// the negative cache, subsequent requests are served from the cache without
+// contacting upstream.
+func TestNegativeCacheStopsUpstreamHits(t *testing.T) {
+	origTTL := config.NegativeCacheTTL
+	config.NegativeCacheTTL = time.Hour
+	defer func() { config.NegativeCacheTTL = origTTL }()
+
+	hitCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitCount++
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer backend.Close()
+
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/missing-file"
+
+	// First request: cache miss, hits upstream, stores negative cache entry.
+	req1 := httptest.NewRequest("GET", "/"+hostAndPath, nil)
+	w1 := httptest.NewRecorder()
+	handleGet(w1, req1)
+	if w1.Result().StatusCode != http.StatusNotFound {
+		t.Fatalf("first request: want 404, got %d", w1.Result().StatusCode)
+	}
+	if hitCount != 1 {
+		t.Fatalf("first request: want 1 upstream hit, got %d", hitCount)
+	}
+
+	// Second request: must be served from negative cache, no upstream hit.
+	req2 := httptest.NewRequest("GET", "/"+hostAndPath, nil)
+	w2 := httptest.NewRecorder()
+	handleGet(w2, req2)
+	if w2.Result().StatusCode != http.StatusNotFound {
+		t.Fatalf("second request: want 404, got %d", w2.Result().StatusCode)
+	}
+	if hitCount != 1 {
+		t.Errorf("second request hit upstream again (want still 1, got %d)", hitCount)
+	}
+}
+
+// TestNegativeCachePatchInvalidates verifies that a PATCH request clears the
+// negative cache entry so the next GET re-fetches from upstream.
+func TestNegativeCachePatchInvalidates(t *testing.T) {
+	origTTL := config.NegativeCacheTTL
+	config.NegativeCacheTTL = time.Hour
+	defer func() { config.NegativeCacheTTL = origTTL }()
+
+	callCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			http.Error(w, "not found", http.StatusNotFound)
+		} else {
+			w.Write([]byte("now it exists"))
+		}
+	}))
+	defer backend.Close()
+
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/appears-later"
+
+	// Prime the negative cache.
+	req1 := httptest.NewRequest("GET", "/"+hostAndPath, nil)
+	handleGet(httptest.NewRecorder(), req1)
+	if callCount != 1 {
+		t.Fatalf("prime: want 1 upstream call, got %d", callCount)
+	}
+	if !cache.isNotFound("http://" + hostAndPath) {
+		t.Fatal("expected negative cache entry after first 404")
+	}
+
+	// PATCH should invalidate the negative cache entry.
+	reqPatch := httptest.NewRequest("PATCH", "/"+hostAndPath, nil)
+	wPatch := httptest.NewRecorder()
+	handleGet(wPatch, reqPatch)
+	if cache.isNotFound("http://" + hostAndPath) {
+		t.Error("negative cache entry should be cleared after PATCH")
+	}
+
+	// Next GET must re-fetch (entry is now available upstream).
+	req2 := httptest.NewRequest("GET", "/"+hostAndPath, nil)
+	w2 := httptest.NewRecorder()
+	handleGet(w2, req2)
+	if w2.Result().StatusCode != http.StatusOK {
+		t.Fatalf("GET after PATCH: want 200, got %d", w2.Result().StatusCode)
+	}
+	if callCount != 2 {
+		t.Errorf("GET after PATCH: want 2 upstream calls, got %d", callCount)
+	}
+}
+
+// TestNegativeCacheTTLExpiry verifies that an expired negative cache entry
+// allows upstream to be contacted again.
+func TestNegativeCacheTTLExpiry(t *testing.T) {
+	origTTL := config.NegativeCacheTTL
+	config.NegativeCacheTTL = 1 * time.Millisecond
+	defer func() { config.NegativeCacheTTL = origTTL }()
+
+	hitCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitCount++
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer backend.Close()
+
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/ttl-test-file"
+
+	// First request: stores negative cache entry.
+	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+hostAndPath, nil))
+	if hitCount != 1 {
+		t.Fatalf("first request: want 1 upstream hit, got %d", hitCount)
+	}
+
+	// Wait for the TTL to expire.
+	time.Sleep(5 * time.Millisecond)
+
+	// Second request: TTL expired, must hit upstream again.
+	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+hostAndPath, nil))
+	if hitCount != 2 {
+		t.Errorf("after TTL expiry: want 2 upstream hits, got %d", hitCount)
+	}
+}
+
+// TestNegativeCacheRuleOverridesTTL verifies that a per-URL rule in
+// NegativeCacheRules takes precedence over the default NegativeCacheTTL.
+func TestNegativeCacheRuleOverridesTTL(t *testing.T) {
+	origTTL := config.NegativeCacheTTL
+	origRules := config.NegativeCacheRules
+	config.NegativeCacheTTL = time.Hour
+	config.NegativeCacheRules = map[string]CachingRules{
+		"short-ttl-rule": {
+			Regex:         ".*short-ttl.*",
+			TTL:           1 * time.Millisecond,
+			CompiledRegex: mustCompileRegex(".*short-ttl.*"),
+		},
+	}
+	defer func() {
+		config.NegativeCacheTTL = origTTL
+		config.NegativeCacheRules = origRules
+	}()
+
+	hitCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitCount++
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer backend.Close()
+
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/short-ttl-resource"
+
+	// First request: stores negative cache entry with 1ms TTL (from rule).
+	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+hostAndPath, nil))
+	if hitCount != 1 {
+		t.Fatalf("first request: want 1 upstream hit, got %d", hitCount)
+	}
+
+	// Wait for the rule TTL (1ms) to expire, default (1h) has not expired.
+	time.Sleep(5 * time.Millisecond)
+
+	// Second request: rule TTL expired, must hit upstream again.
+	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+hostAndPath, nil))
+	if hitCount != 2 {
+		t.Errorf("after rule TTL expiry: want 2 upstream hits, got %d", hitCount)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -201,7 +201,7 @@ func TestHandleGetRemoteNonOKStatus(t *testing.T) {
 
 // TestNegativeCacheStopsUpstreamHits verifies that after a 404 is stored in
 // the negative cache, subsequent requests are served from the cache without
-// contacting upstream.
+// contacting upstream, and that the correct response headers are set.
 func TestNegativeCacheStopsUpstreamHits(t *testing.T) {
 	origTTL := config.NegativeCacheTTL
 	config.NegativeCacheTTL = time.Hour
@@ -217,25 +217,50 @@ func TestNegativeCacheStopsUpstreamHits(t *testing.T) {
 	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/missing-file"
 
 	// First request: cache miss, hits upstream, stores negative cache entry.
+	// Must get X-Pkgproxy-Error and X-Pkgproxy-Cache-Expires.
+	before := time.Now()
 	req1 := httptest.NewRequest("GET", "/"+hostAndPath, nil)
 	w1 := httptest.NewRecorder()
 	handleGet(w1, req1)
-	if w1.Result().StatusCode != http.StatusNotFound {
-		t.Fatalf("first request: want 404, got %d", w1.Result().StatusCode)
+	resp1 := w1.Result()
+	if resp1.StatusCode != http.StatusNotFound {
+		t.Fatalf("first request: want 404, got %d", resp1.StatusCode)
 	}
 	if hitCount != 1 {
 		t.Fatalf("first request: want 1 upstream hit, got %d", hitCount)
 	}
+	if got := resp1.Header.Get("X-Pkgproxy-Error"); got != "remote returned HTTP 404" {
+		t.Errorf("first request X-Pkgproxy-Error: want %q, got %q", "remote returned HTTP 404", got)
+	}
+	expiresStr := resp1.Header.Get("X-Pkgproxy-Cache-Expires")
+	if expiresStr == "" {
+		t.Error("first request: X-Pkgproxy-Cache-Expires header missing")
+	} else {
+		expiry, err := time.Parse(time.RFC3339, expiresStr)
+		if err != nil {
+			t.Errorf("first request: X-Pkgproxy-Cache-Expires not RFC3339: %s", expiresStr)
+		} else if expiry.Before(before.Add(59 * time.Minute)) {
+			t.Errorf("first request: expiry %s is earlier than expected (want ~1h from now)", expiresStr)
+		}
+	}
 
 	// Second request: must be served from negative cache, no upstream hit.
+	// Must get X-Pkgproxy-Negative-Cache: HIT and X-Pkgproxy-Cache-Expires.
 	req2 := httptest.NewRequest("GET", "/"+hostAndPath, nil)
 	w2 := httptest.NewRecorder()
 	handleGet(w2, req2)
-	if w2.Result().StatusCode != http.StatusNotFound {
-		t.Fatalf("second request: want 404, got %d", w2.Result().StatusCode)
+	resp2 := w2.Result()
+	if resp2.StatusCode != http.StatusNotFound {
+		t.Fatalf("second request: want 404, got %d", resp2.StatusCode)
 	}
 	if hitCount != 1 {
 		t.Errorf("second request hit upstream again (want still 1, got %d)", hitCount)
+	}
+	if got := resp2.Header.Get("X-Pkgproxy-Negative-Cache"); got != "HIT" {
+		t.Errorf("second request X-Pkgproxy-Negative-Cache: want %q, got %q", "HIT", got)
+	}
+	if resp2.Header.Get("X-Pkgproxy-Cache-Expires") == "" {
+		t.Error("second request: X-Pkgproxy-Cache-Expires header missing")
 	}
 }
 
@@ -265,7 +290,7 @@ func TestNegativeCachePatchInvalidates(t *testing.T) {
 	if callCount != 1 {
 		t.Fatalf("prime: want 1 upstream call, got %d", callCount)
 	}
-	if !cache.isNotFound("http://" + hostAndPath) {
+	if found, _ := cache.isNotFound("http://" + hostAndPath); !found {
 		t.Fatal("expected negative cache entry after first 404")
 	}
 
@@ -273,7 +298,7 @@ func TestNegativeCachePatchInvalidates(t *testing.T) {
 	reqPatch := httptest.NewRequest("PATCH", "/"+hostAndPath, nil)
 	wPatch := httptest.NewRecorder()
 	handleGet(wPatch, reqPatch)
-	if cache.isNotFound("http://" + hostAndPath) {
+	if found, _ := cache.isNotFound("http://" + hostAndPath); found {
 		t.Error("negative cache entry should be cleared after PATCH")
 	}
 


### PR DESCRIPTION
## Problem

Upstream 404 responses were never cached. Every request for a URL that returns 404 hit the upstream proxy unconditionally. A 14-hour sample from the live instance showed **13,645 upstream hits across only 71 unique 404 URLs** — the same dead endpoints queried over and over, in some cases hundreds of times per hour.

Top offenders from the log:

| URL | Hits |
|-----|------|
| `archive.debian.org/debian/dists/stretch/InRelease` | 1,537 |
| `nginx.org/packages/debian/dists/jessie/nginx/i18n/Translation-en*` (all compression variants) | ~578 each |
| `nginx.org/packages/debian/dists/jessie/nginx/binary-amd64/Packages.*` | ~562 each |
| `download.copr.fedorainfracloud.org/.../mise/epel-9-x86_64/repodata/repomd.xml` | 438 (multiple/sec from same IP) |
| `archive.debian.org/debian-security/dists/jessie/updates/*/i18n/Translation-en_US*` | ~137 each × 10 URLs |

The pattern: EOL distros (Debian jessie, stretch) whose repos are gone or incomplete, and broken third-party repos. `apt` and `dnf` poll them on every update run; without negative caching the proxy forwards every single probe to upstream.

## Solution

When upstream returns 404, pkgproxy now writes a zero-byte sentinel file (`<cache-path>.404`) and records the URL in an in-memory map. Subsequent requests for the same URL are served immediately from the negative cache with a 404, without contacting upstream.

The feature is opt-in via two new config keys that mirror the existing positive-cache config:

```yaml
# Cache 404 responses for 1 hour by default.
negative_cache_ttl: 1h

# Per-URL overrides — same regex/ttl structure as caching_rules.
negative_caching_rules:
  EOL Debian archive:
    regex: 'archive\.debian\.org/.*'
    ttl: 24h
  EOL nginx jessie:
    regex: 'nginx\.org/packages/debian/dists/jessie/.*'
    ttl: 168h # 1 week — these will never come back
```

If `negative_cache_ttl` is not set, the feature is entirely disabled and behaviour is unchanged.

**PATCH invalidation** works the same way as for positive cache entries: a PATCH request clears the negative cache entry so the next GET re-fetches from upstream. This handles the case where a previously 404-ing URL starts serving content (e.g. a repo that was temporarily broken).

**Restart persistence**: on startup, existing `.404` sentinel files are scanned and loaded back into the in-memory map (using the file's mtime as the cache timestamp), so negative cache entries survive service restarts.

**Thundering herd protection**: concurrent requests for a URL that is currently being fetched (and will 404) queue on the busy lock in `cache.has()`. After the lock is released, each waiter re-checks `isNotFound` before attempting its own upstream fetch, so only the first goroutine hits upstream.

## Changes

**[`config.go:41–43`](https://github.com/xorpaul/pkgproxy/blob/cache_404s/config.go#L41)** — two new `Config` fields: `NegativeCacheTTLString`/`NegativeCacheTTL` and `NegativeCacheRules` (reuses the existing `CachingRules` struct). Parsed in `LoadConfig` with the same regex-compile + duration-parse logic as `caching_rules`.

**[`cache.go:23`](https://github.com/xorpaul/pkgproxy/blob/cache_404s/cache.go#L23)** — `notFoundItems map[string]time.Time` added to the `Cache` struct.

**[`cache.go:72–91`](https://github.com/xorpaul/pkgproxy/blob/cache_404s/cache.go#L72)** — `prefillCache` closure extended to recognise `.404` sentinel files, decode their URL, and populate `notFoundItems` with the file's mtime.

**[`cache.go:395–461`](https://github.com/xorpaul/pkgproxy/blob/cache_404s/cache.go#L395)** — four new cache methods: `negativeCacheTTL` (per-URL TTL lookup walking `NegativeCacheRules`), `isNotFound` (map lookup + TTL check), `putNotFound` (writes sentinel file + updates in-memory map), `deleteNotFoundEntry` (removes from map + deletes sentinel file, best-effort).

**[`main.go:315–360`](https://github.com/xorpaul/pkgproxy/blob/cache_404s/main.go#L315)** — request handler additions: PATCH clears negative cache entry before the fast path; non-PATCH requests get a `NEGATIVE_CACHE_HIT` short-circuit before `cache.has()`; post-`has()` re-check for thundering-herd protection; `GetRemote` 404 path calls `putNotFound` instead of `handleError`.

**[`main.go:196–208`](https://github.com/xorpaul/pkgproxy/blob/cache_404s/main.go#L196)** — three new Prometheus counters: `pkgproxy_negative_cache_hit_total`, `pkgproxy_negative_cache_put_total`, `pkgproxy_negative_cache_invalidate_total`.

**[`example.yaml`](https://github.com/xorpaul/pkgproxy/blob/cache_404s/example.yaml)** — documented the new keys with commented-out examples matching the live patterns from the log analysis.

## Tests

Four new tests in `main_test.go`:

- **`TestNegativeCacheStopsUpstreamHits`** — after a first 404, a second request is served from negative cache; backend is contacted exactly once.
- **`TestNegativeCachePatchInvalidates`** — after priming the negative cache, a PATCH clears the entry; the next GET re-fetches and returns 200.
- **`TestNegativeCacheTTLExpiry`** — after the TTL expires, the next request hits upstream again.
- **`TestNegativeCacheRuleOverridesTTL`** — a matching `negative_caching_rules` entry uses its own TTL instead of the default.

## Test plan

- [x] `go test ./...` passes
- [x] Service starts with `negative_cache_ttl` unset — behaviour identical to before this PR
- [x] Service starts with `negative_cache_ttl: 5s` — a URL that 404s is served from negative cache for 5 s, then re-fetches upstream
- [ ] A PATCH to a negative-cached URL clears the entry; subsequent GET reaches upstream
- [x] Restart with sentinel files on disk — negative cache entries are restored and the Prometheus `hit` counter increments on the next request without an upstream call
- [x] `negative_caching_rules` regex match overrides the default TTL
