### PR TITLE
Add negative caching for 404 responses with informative response headers

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -465,6 +466,96 @@ func (c *Cache) deleteNotFoundEntry(requestedURL string) {
 	if err := os.Remove(sentinelFile); err != nil && !os.IsNotExist(err) {
 		olo.Debug("could not remove expired .404 sentinel %s: %s", sentinelFile, err)
 	}
+}
+
+// invalidateByPrefix removes all metadata cache entries (positive and negative)
+// whose URL begins with urlPrefix and whose URL matches at least one of the
+// provided metadata patterns. Package binaries that do not match any pattern
+// are left untouched. Returns the number of cache entries removed.
+func (c *Cache) invalidateByPrefix(urlPrefix string, patterns []*regexp.Regexp) (int, error) {
+	cacheFolder := config.CacheFolder
+	scheme := "http://"
+	if strings.HasPrefix(urlPrefix, "https://") {
+		cacheFolder = config.CacheFolderHTTPS
+		scheme = "https://"
+	}
+
+	withoutScheme := strings.TrimPrefix(strings.TrimPrefix(urlPrefix, "https://"), "http://")
+	parts := strings.SplitN(withoutScheme, "/", 2)
+	domain := parts[0]
+	pathPrefix := ""
+	if len(parts) > 1 {
+		pathPrefix = parts[1]
+	}
+
+	domainDir := filepath.Join(cacheFolder, domain)
+	entries, err := os.ReadDir(domainDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	encodedPrefix := url.QueryEscape(pathPrefix)
+
+	type target struct {
+		filePath string
+		fullURL  string
+	}
+	var toDelete []target
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		baseName := strings.TrimSuffix(name, ".404")
+
+		if !strings.HasPrefix(baseName, encodedPrefix) {
+			continue
+		}
+
+		decodedPath, decErr := url.QueryUnescape(baseName)
+		if decErr != nil {
+			continue
+		}
+		fullURL := scheme + domain + "/" + decodedPath
+
+		matched := false
+		for _, pat := range patterns {
+			if pat.MatchString(fullURL) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+
+		toDelete = append(toDelete, target{
+			filePath: filepath.Join(domainDir, name),
+			fullURL:  fullURL,
+		})
+	}
+
+	c.mutex.Lock()
+	for _, item := range toDelete {
+		delete(c.cacheMemoryItems, item.fullURL)
+		delete(c.notFoundItems, item.fullURL)
+	}
+	c.mutex.Unlock()
+
+	count := 0
+	for _, item := range toDelete {
+		if err := os.Remove(item.filePath); err != nil && !os.IsNotExist(err) {
+			olo.Debug("invalidateByPrefix: could not remove %s: %s", item.filePath, err)
+		} else {
+			count++
+		}
+	}
+
+	return count, nil
 }
 
 func (c *Cache) fillInMemoryCacheWithFileContent(file string, requestedURL string) error {

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"os"
@@ -13,6 +14,21 @@ import (
 	olo "github.com/xorpaul/sigolo"
 	yaml "gopkg.in/yaml.v2"
 )
+
+// defaultMetadataPatternStrings lists the built-in regex patterns used by
+// DELETE requests to identify repo metadata files (APT and YUM/DNF repos).
+// Overridden by metadata_file_patterns in the config file.
+var defaultMetadataPatternStrings = []string{
+	`.*/Packages(\.gz|\.bz2|\.xz|\.zst)?$`,
+	`.*/Sources(\.gz|\.bz2|\.xz|\.zst)?$`,
+	`.*/InRelease$`,
+	`.*/Release(\.gpg)?$`,
+	`.*/Translation-[^/]+$`,
+	`.*/Contents-[^/]+(\.(gz|bz2|xz|zst))?$`,
+	`.*/repomd\.xml$`,
+	`.*/repodata/.*\.(xml|sqlite)(\.gz|\.bz2|\.xz|\.zst)?$`,
+	`.*/.*\.db(\.gz|\.bz2|\.xz|\.zst)?$`,
+}
 
 type Config struct {
 	Debug                      bool     `yaml:"debug"`
@@ -40,8 +56,10 @@ type Config struct {
 	CacheRules                 map[string]CachingRules `yaml:"caching_rules"`
 	NegativeCacheTTLString     string                  `yaml:"negative_cache_ttl"`
 	NegativeCacheTTL           time.Duration
-	NegativeCacheRules         map[string]CachingRules `yaml:"negative_caching_rules"`
-	ReturnCacheIfRemoteFails   bool                    `yaml:"return_cache_if_remote_fails"`
+	NegativeCacheRules              map[string]CachingRules `yaml:"negative_caching_rules"`
+	MetadataPatterns                []string                `yaml:"metadata_file_patterns"`
+	CompiledMetadataPatterns        []*regexp.Regexp
+	ReturnCacheIfRemoteFails        bool `yaml:"return_cache_if_remote_fails"`
 	PrometheusMetricPrefix     string                  `yaml:"prometheus_metric_prefix"`
 	ListenAddressPrometheus    string                  `yaml:"listen_address_prometheus"`
 	ListenPortPrometheus       int                     `yaml:"listen_port_prometheus"`
@@ -145,6 +163,18 @@ func LoadConfig(path string) (*Config, error) {
 	config.CacheFolderHTTPS, err = filepath.Abs(config.CacheFolderHTTPS)
 	if err != nil {
 		return nil, err
+	}
+
+	patterns := config.MetadataPatterns
+	if len(patterns) == 0 {
+		patterns = defaultMetadataPatternStrings
+	}
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid metadata_file_patterns entry %q: %w", p, err)
+		}
+		config.CompiledMetadataPatterns = append(config.CompiledMetadataPatterns, re)
 	}
 
 	olo.Debug("using config settings: %+v", config)

--- a/example.yaml
+++ b/example.yaml
@@ -32,6 +32,21 @@ caching_rules:
   RPM Packages:
     regex: '.*\.rpm$'
     ttl: 8544h # 1 year
+# Bulk metadata cache invalidation via HTTP DELETE:
+#   DELETE http://pkgproxy/http://repo.example.com/dists/
+# removes all cached metadata files under that URL prefix (Packages, Release,
+# repomd.xml, etc.) from both positive and negative cache. Package binaries
+# (.deb, .rpm) are left untouched. Use this to fix stale repo metadata in
+# CI/CD pipelines without clearing the entire cache.
+#
+# Override which files are treated as metadata (default covers APT and YUM/DNF):
+#metadata_file_patterns:
+#  - '.*/Packages(\.gz|\.bz2|\.xz)?$'
+#  - '.*/Release(\.gpg)?$'
+#  - '.*/InRelease$'
+#  - '.*/repomd\.xml$'
+#  - '.*/repodata/.*\.xml(\.gz|\.bz2|\.xz)?$'
+
 # Cache 404 responses to avoid hammering upstream with repeated requests for
 # URLs that don't exist (e.g. EOL distro repos, missing translation files).
 # PATCH requests invalidate negative cache entries, same as positive cache.

--- a/main.go
+++ b/main.go
@@ -205,6 +205,10 @@ func prepare() {
 		Name: config.PrometheusMetricPrefix + "pkgproxy_negative_cache_invalidate_total",
 		Help: "The total number of negative cache entries cleared by PATCH requests",
 	})
+	promCounters["CACHE_PREFIX_INVALIDATE"] = promauto.NewCounter(prometheus.CounterOpts{
+		Name: config.PrometheusMetricPrefix + "pkgproxy_cache_prefix_invalidation_total",
+		Help: "The total number of DELETE requests that performed metadata cache invalidation",
+	})
 
 	promSummaries = make(map[string]prometheus.Summary)
 	promSummaries["CACHE_READ_MEMORY"] = promauto.NewSummary(prometheus.SummaryOpts{
@@ -226,7 +230,7 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	olo.Info("Incoming request '%s' from '%s' on '%s'", r.URL.String(), requesterIP, r.Host)
-	if r.Method != "GET" && r.Method != "HEAD" && r.Method != "PATCH" {
+	if r.Method != "GET" && r.Method != "HEAD" && r.Method != "PATCH" && r.Method != "DELETE" {
 		olo.Warn("Incoming nonGET HTTP request '%s' from '%s' on '%s'", r.URL.Path, requesterIP, r.Host)
 		errorMessage := fmt.Sprintf("HTTP method '%s' other than GET, HEAD or PATCH not allowed for '%s' from '%s' on '%s'", r.Method, r.URL, requesterIP, r.Host)
 		promCounters["TOTAL_HTTP_NONGET_REQUESTS"].Inc()
@@ -254,6 +258,33 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 			olo.Debug("setting default ttl to '%s' for service name '%s'", defaultCacheTTL.String(), r.Host)
 			break
 		}
+	}
+
+	if r.Method == "DELETE" {
+		delURL := strings.TrimLeft(r.URL.String(), "/")
+		if strings.Contains(delURL, "..") {
+			http.Error(w, ".. not allowed in request URL", http.StatusBadRequest)
+			return
+		}
+		switch {
+		case strings.HasPrefix(delURL, "https:"):
+			protocol = "https://"
+			delURL = strings.TrimPrefix(delURL, "https:")
+		case strings.HasPrefix(delURL, "http:"):
+			protocol = "http://"
+			delURL = strings.TrimPrefix(delURL, "http:")
+		}
+		urlPrefix := protocol + delURL
+		count, err := cache.invalidateByPrefix(urlPrefix, config.CompiledMetadataPatterns)
+		if err != nil {
+			handleError(nil, err, w)
+			return
+		}
+		promCounters["CACHE_PREFIX_INVALIDATE"].Inc()
+		olo.Info("DELETE invalidated %d metadata cache entries for prefix '%s' from '%s'", count, urlPrefix, requesterIP)
+		w.Header().Set("X-Pkgproxy-Invalidated", strconv.Itoa(count))
+		fmt.Fprintf(w, "Invalidated %d metadata cache entries for prefix: %s\n", count, urlPrefix)
+		return
 	}
 
 	cacheURL := strings.TrimLeft(r.URL.String(), "/")

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+
 func mustCompileRegex(s string) *regexp.Regexp {
 	return regexp.MustCompile(s)
 }
@@ -35,13 +36,19 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
+	compiledMetadataPatterns := make([]*regexp.Regexp, 0, len(defaultMetadataPatternStrings))
+	for _, p := range defaultMetadataPatternStrings {
+		compiledMetadataPatterns = append(compiledMetadataPatterns, regexp.MustCompile(p))
+	}
+
 	config = &Config{
-		CacheFolder:            cacheDir,
-		CacheFolderHTTPS:       cacheHTTPSDir,
-		DefaultCacheTTL:        time.Hour,
-		MaxCacheItemSize:       100,
-		Timeout:                5,
-		PrometheusMetricPrefix: "test_",
+		CacheFolder:              cacheDir,
+		CacheFolderHTTPS:         cacheHTTPSDir,
+		DefaultCacheTTL:          time.Hour,
+		MaxCacheItemSize:         100,
+		Timeout:                  5,
+		PrometheusMetricPrefix:   "test_",
+		CompiledMetadataPatterns: compiledMetadataPatterns,
 	}
 
 	client = &http.Client{Timeout: 5 * time.Second}
@@ -64,6 +71,7 @@ func initTestMetrics() {
 		"CACHE_HIT", "CACHE_MISS", "CACHE_INVALIDATE", "CACHE_TOO_OLD",
 		"CACHE_OK", "CACHE_ITEM_MISSING",
 		"NEGATIVE_CACHE_HIT", "NEGATIVE_CACHE_PUT", "NEGATIVE_CACHE_INVALIDATE",
+		"CACHE_PREFIX_INVALIDATE",
 	} {
 		promCounters[name] = prometheus.NewCounter(prometheus.CounterOpts{Name: "test_noop"})
 	}
@@ -343,6 +351,100 @@ func TestNegativeCacheTTLExpiry(t *testing.T) {
 	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+hostAndPath, nil))
 	if hitCount != 2 {
 		t.Errorf("after TTL expiry: want 2 upstream hits, got %d", hitCount)
+	}
+}
+
+// TestDeleteInvalidatesMetadataFiles verifies that a DELETE request removes
+// cached metadata files under the given prefix while leaving package binaries
+// untouched. It also checks the X-Pkgproxy-Invalidated response header.
+func TestDeleteInvalidatesMetadataFiles(t *testing.T) {
+	callCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Write([]byte("content"))
+	}))
+	defer backend.Close()
+
+	host := strings.TrimPrefix(backend.URL, "http://")
+	metaPath := host + "/dists/focal/Packages"
+	pkgPath := host + "/pool/main/p/pkg/pkg_1.0_amd64.deb"
+
+	// Prime the cache with a metadata file and a package file.
+	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+metaPath, nil))
+	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+pkgPath, nil))
+	if callCount != 2 {
+		t.Fatalf("priming: want 2 backend calls, got %d", callCount)
+	}
+
+	// Verify both are in the memory cache.
+	if _, ok := cache.cacheMemoryItems["http://"+metaPath]; !ok {
+		t.Fatal("metadata file not in cache after GET")
+	}
+	if _, ok := cache.cacheMemoryItems["http://"+pkgPath]; !ok {
+		t.Fatal("package file not in cache after GET")
+	}
+
+	// DELETE the dists/ prefix — should remove Packages but not the .deb.
+	delReq := httptest.NewRequest("DELETE", "/"+host+"/dists/", nil)
+	delW := httptest.NewRecorder()
+	handleGet(delW, delReq)
+
+	delResp := delW.Result()
+	if delResp.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE status: want 200, got %d", delResp.StatusCode)
+	}
+	if got := delResp.Header.Get("X-Pkgproxy-Invalidated"); got != "1" {
+		t.Errorf("X-Pkgproxy-Invalidated: want %q, got %q", "1", got)
+	}
+
+	// Metadata file must be gone from memory cache.
+	if _, ok := cache.cacheMemoryItems["http://"+metaPath]; ok {
+		t.Error("metadata file still in memory cache after DELETE")
+	}
+	// Package file must still be cached.
+	if _, ok := cache.cacheMemoryItems["http://"+pkgPath]; !ok {
+		t.Error("package file was incorrectly removed from cache by DELETE")
+	}
+
+	// Next GET for the metadata file must hit backend again (cache miss).
+	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+metaPath, nil))
+	if callCount != 3 {
+		t.Errorf("GET after DELETE: want 3 backend calls (re-fetch), got %d", callCount)
+	}
+}
+
+// TestDeleteInvalidatesNegativeCacheEntries verifies that DELETE also clears
+// negative cache (.404) entries for metadata files under the given prefix.
+func TestDeleteInvalidatesNegativeCacheEntries(t *testing.T) {
+	origTTL := config.NegativeCacheTTL
+	config.NegativeCacheTTL = time.Hour
+	defer func() { config.NegativeCacheTTL = origTTL }()
+
+	hitCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitCount++
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer backend.Close()
+
+	host := strings.TrimPrefix(backend.URL, "http://")
+	metaPath := host + "/repodata/repomd.xml"
+
+	// Prime the negative cache.
+	handleGet(httptest.NewRecorder(), httptest.NewRequest("GET", "/"+metaPath, nil))
+	if hitCount != 1 {
+		t.Fatalf("prime: want 1 upstream call, got %d", hitCount)
+	}
+	if found, _ := cache.isNotFound("http://" + metaPath); !found {
+		t.Fatal("expected negative cache entry after 404")
+	}
+
+	// DELETE the repodata/ prefix — should clear the negative cache entry.
+	delReq := httptest.NewRequest("DELETE", "/"+host+"/repodata/", nil)
+	handleGet(httptest.NewRecorder(), delReq)
+
+	if found, _ := cache.isNotFound("http://" + metaPath); found {
+		t.Error("negative cache entry still present after DELETE")
 	}
 }
 


### PR DESCRIPTION
### Problem

When an upstream repository publishes a new snapshot — new packages added, metadata regenerated, signing keys rotated — pkgproxy's cached metadata files (`Packages`, `repomd.xml`, `Release`, `InRelease`, etc.) can lag behind. CI/CD pipelines that hit pkgproxy during this window get stale indexes and either fail with signature errors or install the wrong package versions.

The only existing tool is `PATCH`, which invalidates **one URL at a time**. A typical APT repo has a dozen metadata files per suite/component/arch combination; a YUM repo has four or more `repodata/` entries per architecture. Invalidating them one-by-one is tedious and error-prone.

### Solution

Add a `DELETE` method that bulk-invalidates all cached **metadata** entries under a URL prefix in a single request:

```
DELETE http://pkgproxy/http://apt.puppetlabs.com/dists/focal/puppet7/
DELETE http://pkgproxy/https://download.copr.fedorainfracloud.org/results/jdoss/mise/epel-9-x86_64/repodata/
```

The response body and `X-Pkgproxy-Invalidated: N` header report how many cache entries were removed. Package binaries (`.deb`, `.rpm`, etc.) are **never touched** — only recognized metadata files are cleared. Each cleared entry is re-fetched from upstream on the next GET.

Both positive cache files **and** negative cache `.404` sentinels are cleared, so a repo that previously returned 404s for new metadata will also be unblocked by a single DELETE.

### What counts as metadata

Built-in defaults cover APT and YUM/DNF repositories (defined in [`config.go:21`](https://github.com/xorpaul/pkgproxy/blob/support_repo_metadata_cache_invalidation/config.go#L21)):

| Pattern | Covers |
|---------|--------|
| `.*/Packages(\.gz\|\.bz2\|\.xz\|\.zst)?$` | APT package index |
| `.*/Sources(\.gz\|\.bz2\|\.xz\|\.zst)?$` | APT source index |
| `.*/InRelease$` | APT signed release file |
| `.*/Release(\.gpg)?$` | APT release + detached signature |
| `.*/Translation-[^/]+$` | APT package descriptions |
| `.*/Contents-[^/]+(\.(gz\|bz2\|xz\|zst))?$` | APT contents index |
| `.*/repomd\.xml$` | YUM/DNF primary metadata pointer |
| `.*/repodata/.*\.(xml\|sqlite)(\.gz\|\.bz2\|\.xz\|\.zst)?$` | YUM/DNF data files |
| `.*/.*\.db(\.gz\|\.bz2\|\.xz\|\.zst)?$` | DNF sqlite databases |

Operators who proxy non-standard repos can override via `metadata_file_patterns` in the config file (documented in `example.yaml`).

### Implementation

**[`cache.go:475`](https://github.com/xorpaul/pkgproxy/blob/support_repo_metadata_cache_invalidation/cache.go#L475) — `invalidateByPrefix()`**

Reads the domain's cache directory with `os.ReadDir`, URL-decodes each filename to reconstruct the full URL, checks it against the compiled metadata patterns, then removes matching keys from `cacheMemoryItems` and `notFoundItems` under `c.mutex` and deletes the files from disk. In-flight fetches (`busyItems`) are intentionally left alone — their `release()` writes a fresh file when they complete.

**[`main.go:263`](https://github.com/xorpaul/pkgproxy/blob/support_repo_metadata_cache_invalidation/main.go#L263) — DELETE fast-path in `handleGet()`**

Branches before `validateCacheURL` (which rejects trailing slashes) so prefix URLs like `.../dists/` are accepted. Path-traversal (`..`) is still rejected. The scheme (`http:`/`https:`) is parsed from the URL itself, same as for GET/PATCH.

**[`config.go:60`](https://github.com/xorpaul/pkgproxy/blob/support_repo_metadata_cache_invalidation/config.go#L60) — new config fields**

`MetadataPatterns []string` (YAML: `metadata_file_patterns`) and the compiled `[]*regexp.Regexp` slice. If `metadata_file_patterns` is absent, the built-in defaults from [`config.go:21`](https://github.com/xorpaul/pkgproxy/blob/support_repo_metadata_cache_invalidation/config.go#L21) are compiled at startup.

**New Prometheus counter**: `pkgproxy_cache_prefix_invalidation_total` — counts DELETE requests that ran an invalidation pass (regardless of how many entries were removed).

### Tests

Two new test cases in `main_test.go`:

- **`TestDeleteInvalidatesMetadataFiles`** — primes cache with a `Packages` file and a `.deb`; sends `DELETE` on the `dists/` prefix; verifies `X-Pkgproxy-Invalidated: 1`, that `Packages` is evicted from the memory cache and re-fetched on the next GET, and that the `.deb` is untouched.
- **`TestDeleteInvalidatesNegativeCacheEntries`** — primes the negative cache with a `repomd.xml` 404; sends `DELETE` on the `repodata/` prefix; verifies the negative cache entry is cleared.

### Config example

```yaml
# metadata_file_patterns: override which files are treated as metadata by DELETE requests.
# If omitted, built-in defaults cover APT (Packages, Release, InRelease, ...) and
# YUM/DNF (repomd.xml, repodata/*.xml.gz, ...) repositories.
#metadata_file_patterns:
#  - '.*/Packages(\.gz|\.bz2|\.xz)?$'
#  - '.*/repomd\.xml$'
```

### Test plan

- [ ] `go test ./...` passes
- [ ] `DELETE /http://repo/dists/` returns `X-Pkgproxy-Invalidated: N` and `200 OK` after priming cache with metadata files
- [ ] The cached `.deb` file remains on disk after the DELETE
- [ ] The cleared `Packages` file is re-fetched from upstream on the next GET (CACHE_MISS in logs)
- [ ] `DELETE /http://repo/` with no matching metadata files returns `Invalidated 0 …` with 200 OK (not an error)
- [ ] `DELETE /http://repo/path/to/..evil` returns 400
- [ ] A negative-cached metadata URL (`.404` sentinel) is also cleared by DELETE and the next GET attempts upstream
- [ ] Custom `metadata_file_patterns` in config takes effect: only matching files are removed
- [ ] `pkgproxy_cache_prefix_invalidation_total` increments on each DELETE request
