### PR TITLE
Use upstream ETag/Last-Modified for conditional GET revalidation

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -35,6 +36,49 @@ type CacheResponse struct {
 	content  io.ReadSeeker
 }
 
+// CacheMeta holds HTTP validators (ETag, Last-Modified) from the upstream
+// response. Stored as a JSON sidecar (<cachefile>.meta) and used to issue
+// conditional GETs on the next TTL expiry, avoiding re-downloads when the
+// upstream content has not changed.
+type CacheMeta struct {
+	ETag         string `json:"etag,omitempty"`
+	LastModified string `json:"last_modified,omitempty"`
+}
+
+// cacheFilePath returns the on-disk path pkgproxy would use for requestedURL
+// without creating any directories.
+func cacheFilePath(requestedURL string) (string, error) {
+	cacheFolder := config.CacheFolder
+	if strings.HasPrefix(requestedURL, "https://") {
+		cacheFolder = config.CacheFolderHTTPS
+	}
+	urlParts := strings.SplitN(requestedURL, "/", 4)
+	if len(urlParts) < 4 {
+		return "", fmt.Errorf("invalid URL: %s", requestedURL)
+	}
+	return filepath.Join(cacheFolder, urlParts[2], url.QueryEscape(urlParts[3])), nil
+}
+
+func saveMeta(cacheFile string, meta CacheMeta) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(cacheFile+".meta", data, 0644)
+}
+
+func loadMeta(cacheFile string) CacheMeta {
+	data, err := os.ReadFile(cacheFile + ".meta")
+	if err != nil {
+		return CacheMeta{}
+	}
+	var meta CacheMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return CacheMeta{}
+	}
+	return meta
+}
+
 func CreateCache() (*Cache, error) {
 	cacheFolder, err := h.CheckDirAndCreate(config.CacheFolder, "CreateCache HTTP")
 	if err != nil {
@@ -60,6 +104,10 @@ func CreateCache() (*Cache, error) {
 			return err
 		}
 		if d.IsDir() {
+			return nil
+		}
+		// Meta sidecars are not cache items; skip them.
+		if strings.HasSuffix(d.Name(), ".meta") {
 			return nil
 		}
 		olo.Debug("prefill cache with path: %s", path)
@@ -225,6 +273,11 @@ func (c *Cache) get(requestedURL string, defaultCacheTTL time.Duration, invalida
 		return CacheResponse{}, err
 	}
 
+	// Re-read the memory item: checkCacheTTL may have fetched a newer version.
+	c.mutex.Lock()
+	cacheMemoryItem = c.cacheMemoryItems[requestedURL]
+	c.mutex.Unlock()
+
 	// Key is known, but not found in-memory, read from file
 	if cacheMemoryItem.content == nil {
 		olo.Debug("Cache item '%s' is known but is not stored in memory. Reading from file: %s", cacheURL, cacheFile)
@@ -270,6 +323,19 @@ func (c *Cache) get(requestedURL string, defaultCacheTTL time.Duration, invalida
 func (c *Cache) cancelBusy(requestedURL string) {
 	c.mutex.Lock()
 	delete(c.busyItems, requestedURL)
+	c.mutex.Unlock()
+}
+
+// refreshLoadedAt updates the loadedAt timestamp of an in-memory cache entry
+// without changing its content. Called after a 304 revalidation so that
+// http.ServeContent receives a current Last-Modified and future TTL checks
+// see the refreshed time.
+func (c *Cache) refreshLoadedAt(requestedURL string) {
+	c.mutex.Lock()
+	if item, ok := c.cacheMemoryItems[requestedURL]; ok {
+		item.loadedAt = time.Now()
+		c.cacheMemoryItems[requestedURL] = item
+	}
 	c.mutex.Unlock()
 }
 
@@ -376,6 +442,19 @@ func checkCacheTTL(filePath string, requestedURL string, defaultCacheTTL time.Du
 		} else {
 			olo.Info("CACHE_TOO_OLD for requested URL '%s'", requestedURL)
 			promCounters["CACHE_TOO_OLD"].Inc()
+		}
+		// For PATCH (invalidateCache) skip conditional GET so the full body is
+		// always re-downloaded, preserving the explicit invalidation semantics.
+		if !invalidateCache {
+			if handled, err := tryConditionalGet(requestedURL); err != nil {
+				if config.ReturnCacheIfRemoteFails {
+					olo.Info("conditional GET for %s failed, providing cached item as fallback", requestedURL)
+					return nil
+				}
+				return err
+			} else if handled {
+				return nil
+			}
 		}
 		_, err := GetRemote(requestedURL)
 		if err != nil {
@@ -552,6 +631,7 @@ func (c *Cache) invalidateByPrefix(urlPrefix string, patterns []*regexp.Regexp) 
 			olo.Debug("invalidateByPrefix: could not remove %s: %s", item.filePath, err)
 		} else {
 			count++
+			os.Remove(item.filePath + ".meta")
 		}
 	}
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -237,3 +237,155 @@ func TestCreateCachePrefillsBothHTTPAndHTTPS(t *testing.T) {
 		t.Error("HTTPS cache file not indexed by CreateCache")
 	}
 }
+
+// TestConditionalGet304AvoidRedownload verifies that when a cached item's TTL
+// has expired but the upstream returns 304 Not Modified, pkgproxy revalidates
+// the cache without re-downloading the body, resets the cache file mtime, and
+// serves subsequent requests from cache without hitting the backend again.
+func TestConditionalGet304AvoidRedownload(t *testing.T) {
+	const content = "cached-content"
+	const etag = `"revalidate-etag-abc"`
+
+	var lastRequestHeaders http.Header
+	callCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		lastRequestHeaders = r.Header.Clone()
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+		w.Write([]byte(content))
+	}))
+	defer backend.Close()
+
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/conditional-304-test"
+	fullURL := "http://" + hostAndPath
+	path := "/" + hostAndPath
+
+	// Prime the cache.
+	w1 := httptest.NewRecorder()
+	handleGet(w1, httptest.NewRequest("GET", path, nil))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("initial GET: want 200, got %d", w1.Code)
+	}
+	if callCount != 1 {
+		t.Fatalf("initial GET: want 1 backend call, got %d", callCount)
+	}
+
+	// Verify meta sidecar was written with the ETag.
+	cf, err := cacheFilePath(fullURL)
+	if err != nil {
+		t.Fatalf("cacheFilePath: %v", err)
+	}
+	meta := loadMeta(cf)
+	if meta.ETag != etag {
+		t.Errorf("meta ETag after initial GET: want %q, got %q", etag, meta.ETag)
+	}
+
+	// Age the cache file past the default TTL (1h) to force revalidation.
+	stale := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(cf, stale, stale); err != nil {
+		t.Fatalf("os.Chtimes: %v", err)
+	}
+
+	// Second GET: TTL expired, conditional GET should yield 304 — no body re-download.
+	w2 := httptest.NewRecorder()
+	handleGet(w2, httptest.NewRequest("GET", path, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second GET: want 200, got %d", w2.Code)
+	}
+	if callCount != 2 {
+		t.Fatalf("second GET: want 2 backend calls total, got %d", callCount)
+	}
+	if lastRequestHeaders.Get("If-None-Match") != etag {
+		t.Errorf("second GET: If-None-Match not sent (got %q)", lastRequestHeaders.Get("If-None-Match"))
+	}
+
+	// Cache file mtime should be reset to approximately now.
+	fi, err := os.Stat(cf)
+	if err != nil {
+		t.Fatalf("stat cache file: %v", err)
+	}
+	if time.Since(fi.ModTime()) > 5*time.Second {
+		t.Errorf("cache file mtime not reset after 304 (mtime %v)", fi.ModTime())
+	}
+
+	// Third GET within the fresh TTL: must not hit backend again.
+	w3 := httptest.NewRecorder()
+	handleGet(w3, httptest.NewRequest("GET", path, nil))
+	if w3.Code != http.StatusOK {
+		t.Fatalf("third GET: want 200, got %d", w3.Code)
+	}
+	if callCount != 2 {
+		t.Errorf("third GET: want still 2 backend calls (TTL reset by 304), got %d", callCount)
+	}
+}
+
+// TestConditionalGet200UpdatesCache verifies that when the upstream returns 200
+// on a conditional GET (content changed), pkgproxy updates the cached body and
+// the meta sidecar, and serves the new content on the next request.
+func TestConditionalGet200UpdatesCache(t *testing.T) {
+	const content1 = "original-content"
+	const content2 = "updated-content"
+	const etag1 = `"etag-v1"`
+	const etag2 = `"etag-v2"`
+
+	callCount := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Header.Get("If-None-Match") == etag1 {
+			// Content changed: send new version with new ETag.
+			w.Header().Set("ETag", etag2)
+			w.Write([]byte(content2))
+			return
+		}
+		w.Header().Set("ETag", etag1)
+		w.Write([]byte(content1))
+	}))
+	defer backend.Close()
+
+	hostAndPath := strings.TrimPrefix(backend.URL, "http://") + "/conditional-200-test"
+	fullURL := "http://" + hostAndPath
+	path := "/" + hostAndPath
+
+	// Prime the cache.
+	w1 := httptest.NewRecorder()
+	handleGet(w1, httptest.NewRequest("GET", path, nil))
+	if w1.Code != http.StatusOK {
+		t.Fatalf("initial GET: want 200, got %d", w1.Code)
+	}
+
+	cf, err := cacheFilePath(fullURL)
+	if err != nil {
+		t.Fatalf("cacheFilePath: %v", err)
+	}
+
+	// Age the cache file to force TTL expiry.
+	stale := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(cf, stale, stale); err != nil {
+		t.Fatalf("os.Chtimes: %v", err)
+	}
+
+	// Second GET: TTL expired, conditional GET returns 200 (content changed).
+	w2 := httptest.NewRecorder()
+	handleGet(w2, httptest.NewRequest("GET", path, nil))
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second GET: want 200, got %d", w2.Code)
+	}
+	if callCount != 2 {
+		t.Fatalf("second GET: want 2 backend calls total, got %d", callCount)
+	}
+
+	body, _ := io.ReadAll(w2.Result().Body)
+	if string(body) != content2 {
+		t.Errorf("second GET body: want %q, got %q", content2, string(body))
+	}
+
+	// Meta sidecar should have the updated ETag.
+	meta := loadMeta(cf)
+	if meta.ETag != etag2 {
+		t.Errorf("meta ETag after update: want %q, got %q", etag2, meta.ETag)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -209,6 +209,10 @@ func prepare() {
 		Name: config.PrometheusMetricPrefix + "pkgproxy_cache_prefix_invalidation_total",
 		Help: "The total number of DELETE requests that performed metadata cache invalidation",
 	})
+	promCounters["CACHE_REVALIDATED"] = promauto.NewCounter(prometheus.CounterOpts{
+		Name: config.PrometheusMetricPrefix + "pkgproxy_cache_revalidated_total",
+		Help: "The total number of cache entries revalidated via conditional GET (304 Not Modified)",
+	})
 
 	promSummaries = make(map[string]prometheus.Summary)
 	promSummaries["CACHE_READ_MEMORY"] = promauto.NewSummary(prometheus.SummaryOpts{
@@ -428,6 +432,89 @@ func handleGet(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// tryConditionalGet attempts to revalidate the cached item for requestedURL
+// using HTTP conditional GET (If-None-Match / If-Modified-Since). Returns
+// (true, nil) if the cache was handled (304 kept, or 200 updated). Returns
+// (false, nil) if no validators exist or an unexpected status was received, in
+// which case the caller should fall back to a full GetRemote. Returns
+// (false, err) on transport or caching errors.
+func tryConditionalGet(requestedURL string) (bool, error) {
+	cacheFile, err := cacheFilePath(requestedURL)
+	if err != nil {
+		return false, nil
+	}
+	meta := loadMeta(cacheFile)
+	if meta.ETag == "" && meta.LastModified == "" {
+		return false, nil
+	}
+
+	req, err := http.NewRequest("GET", requestedURL, nil)
+	if err != nil {
+		return false, nil
+	}
+	req.Header.Set("User-Agent", "https://github.com/xorpaul/pkgproxy/")
+	req.Header.Set("Connection", "keep-alive")
+	if meta.ETag != "" {
+		req.Header.Set("If-None-Match", meta.ETag)
+	}
+	if meta.LastModified != "" {
+		req.Header.Set("If-Modified-Since", meta.LastModified)
+	}
+
+	before := time.Now()
+	response, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer response.Body.Close()
+
+	switch response.StatusCode {
+	case http.StatusNotModified:
+		olo.Info("CACHE_REVALIDATED (304 Not Modified) for '%s' in %.5fs", requestedURL, time.Since(before).Seconds())
+		promCounters["CACHE_REVALIDATED"].Inc()
+		now := time.Now()
+		if err := os.Chtimes(cacheFile, now, now); err != nil {
+			olo.Warn("tryConditionalGet: could not touch mtime for %s: %s", cacheFile, err)
+		}
+		cache.refreshLoadedAt(requestedURL)
+		// Some servers echo updated validators in 304; keep existing ones when absent.
+		newETag := response.Header.Get("ETag")
+		newLastModified := response.Header.Get("Last-Modified")
+		if newETag == "" {
+			newETag = meta.ETag
+		}
+		if newLastModified == "" {
+			newLastModified = meta.LastModified
+		}
+		if err := saveMeta(cacheFile, CacheMeta{ETag: newETag, LastModified: newLastModified}); err != nil {
+			olo.Warn("tryConditionalGet: could not save meta for %s: %s", requestedURL, err)
+		}
+		return true, nil
+
+	case http.StatusOK:
+		olo.Info("CACHE_CONDITIONAL_UPDATED (200) for '%s' in %.5fs", requestedURL, time.Since(before).Seconds())
+		promCounters["REMOTE_OK"].Inc()
+		var reader io.Reader = response.Body
+		if err := cache.put(requestedURL, &reader, response.ContentLength); err != nil {
+			return false, err
+		}
+		newMeta := CacheMeta{
+			ETag:         response.Header.Get("ETag"),
+			LastModified: response.Header.Get("Last-Modified"),
+		}
+		if newMeta.ETag != "" || newMeta.LastModified != "" {
+			if err := saveMeta(cacheFile, newMeta); err != nil {
+				olo.Warn("tryConditionalGet: could not save meta for %s: %s", requestedURL, err)
+			}
+		}
+		return true, nil
+
+	default:
+		olo.Debug("tryConditionalGet: unexpected status %d for '%s', falling back to full download", response.StatusCode, requestedURL)
+		return false, nil
+	}
+}
+
 func GetRemote(requestedURL string) (*http.Response, error) {
 	if len(config.Proxy) > 0 {
 		olo.Info("GETing %s with proxy %s", requestedURL, config.Proxy)
@@ -457,6 +544,19 @@ func GetRemote(requestedURL string) (*http.Response, error) {
 		err = cache.put(requestedURL, &reader, response.ContentLength)
 		if err != nil {
 			return response, err
+		}
+		// Persist ETag / Last-Modified so future TTL expiries can use
+		// conditional GETs instead of always re-downloading the full body.
+		metaVals := CacheMeta{
+			ETag:         response.Header.Get("ETag"),
+			LastModified: response.Header.Get("Last-Modified"),
+		}
+		if metaVals.ETag != "" || metaVals.LastModified != "" {
+			if cacheFile, ferr := cacheFilePath(requestedURL); ferr == nil {
+				if merr := saveMeta(cacheFile, metaVals); merr != nil {
+					olo.Warn("GetRemote: could not save meta for %s: %s", requestedURL, merr)
+				}
+			}
 		}
 		defer response.Body.Close()
 		return response, nil

--- a/main_test.go
+++ b/main_test.go
@@ -71,7 +71,7 @@ func initTestMetrics() {
 		"CACHE_HIT", "CACHE_MISS", "CACHE_INVALIDATE", "CACHE_TOO_OLD",
 		"CACHE_OK", "CACHE_ITEM_MISSING",
 		"NEGATIVE_CACHE_HIT", "NEGATIVE_CACHE_PUT", "NEGATIVE_CACHE_INVALIDATE",
-		"CACHE_PREFIX_INVALIDATE",
+		"CACHE_PREFIX_INVALIDATE", "CACHE_REVALIDATED",
 	} {
 		promCounters[name] = prometheus.NewCounter(prometheus.CounterOpts{Name: "test_noop"})
 	}


### PR DESCRIPTION
## What this does

When pkgproxy re-fetches a cached item because its TTL has expired, it previously always downloaded the full body from upstream — even when the content hadn't changed. This PR makes pkgproxy use the HTTP conditional GET mechanism instead: it stores the `ETag` and `Last-Modified` headers from the upstream response in a small JSON sidecar file (`<cachefile>.meta`) alongside each cached file, and on the next TTL expiry it sends `If-None-Match` / `If-Modified-Since` to the upstream before deciding whether to re-download.

For a file like `https://apt.puppetlabs.com/dists/bullseye/InRelease` (83 KB, updated infrequently), an expired TTL now costs one lightweight conditional GET that returns 304 instead of re-transferring the full body. The file is only re-downloaded when the upstream actually has a newer version.

## Behaviour

- **304 Not Modified:** cache content is still valid. pkgproxy touches the cache file mtime (resetting the TTL), updates the in-memory `loadedAt` timestamp so `http.ServeContent` reflects the fresh time downstream, and updates the sidecar with any new validators the server echoed. No body transfer.
- **200 OK:** content has changed. Cache file, in-memory entry, and sidecar are all updated as usual.
- **No sidecar / unexpected status / upstream doesn't send validators:** falls through to the existing full `GetRemote` path unchanged.
- **PATCH requests** skip conditional GET deliberately so explicit cache invalidation always forces a full re-download.

## Files changed

- [`cache.go`](https://github.com/xorpaul/pkgproxy/blob/94d3ecd84de06efd531357f9ea386090fc4cdd30/cache.go) — `CacheMeta` struct; `cacheFilePath`, `saveMeta`, `loadMeta` helpers; `cache.refreshLoadedAt`; `.meta` skipped in `prefillCache`; `.meta` cleaned up by `invalidateByPrefix`; `checkCacheTTL` calls `tryConditionalGet` before `GetRemote`.
- [`main.go`](https://github.com/xorpaul/pkgproxy/blob/94d3ecd84de06efd531357f9ea386090fc4cdd30/main.go) — `tryConditionalGet` function; `GetRemote` saves ETag/Last-Modified after a 200; new `pkgproxy_cache_revalidated_total` Prometheus counter.
- [`cache_test.go`](https://github.com/xorpaul/pkgproxy/blob/94d3ecd84de06efd531357f9ea386090fc4cdd30/cache_test.go) — two new integration tests covering the 304 path (no re-download, mtime reset, TTL refresh) and the 200 path (new content served immediately, sidecar updated).
- [`main_test.go`](https://github.com/xorpaul/pkgproxy/blob/94d3ecd84de06efd531357f9ea386090fc4cdd30/main_test.go) — `CACHE_REVALIDATED` added to test metrics init.

## Side fix: stale in-memory content after TTL expiry

`cache.get` fetched the in-memory item before calling `checkCacheTTL`, then used that stale snapshot after `checkCacheTTL` had potentially replaced the cache with newer content. A re-read after `checkCacheTTL` fixes this. The bug was pre-existing for the `GetRemote`-on-expiry path too (no existing test asserts on the response body after a TTL expiry re-fetch), and is now fixed for both paths.

## Operational notes

**Request frequency is unchanged.** A conditional GET is sent at most once per TTL period per server — exactly as the existing full download was. With the current HAProxy consistent-hash routing, one pkgproxy instance handles each upstream hostname per DC, so upstream request rate per DC is the same as today, just cheaper per request when content is stable.

**Multi-instance / shared filesystem.** `.meta` files are small (one JSON line) and handled with graceful fallback: a missing or corrupt sidecar causes `tryConditionalGet` to short-circuit and fall back to `GetRemote`. On NFS or Syncthing the same TOCTOU properties apply as for the main cache files. `.meta` files are fully disposable and regenerated on the next 200 response.

**Multi-DC Syncthing expansion.** Each DC sends its own conditional GETs independently — Syncthing syncing file content does not propagate mtime in a way pkgproxy tracks. With N DCs you get N conditional GETs per TTL period per popular URL instead of N full re-downloads. The upstream request count is the same as today; the bandwidth saving is significant for stable files.

**No config changes required.** The feature activates automatically for any upstream that sends `ETag` or `Last-Modified`. Existing TTL and caching-rule configuration is respected unchanged.

## Test plan

- [ ] `go test ./...` passes
- [ ] Prime cache for a URL, age the cache file past TTL, make a second request — logs show `CACHE_REVALIDATED (304)` and only 2 upstream hits (not 3 on a third request)
- [ ] Same setup but upstream returns 200 with new content — second request returns updated content, third request is served from cache
- [ ] PATCH on a URL with a `.meta` sidecar still triggers a full re-download (not a 304)
- [ ] `pkgproxy_cache_revalidated_total` increments on each 304 revalidation
- [ ] Upstream without ETag/Last-Modified headers: `.meta` is not written, behaviour is identical to before this PR
